### PR TITLE
Remove canonical titles, fix search for titles with sub-kind, mini-series fix

### DIFF
--- a/imdb/__init__.py
+++ b/imdb/__init__.py
@@ -825,7 +825,7 @@ class IMDbBase:
         #      subclass, somewhere under the imdb.parser package.
         raise NotImplementedError('override this method')
 
-    def _searchIMDb(self, kind, ton):
+    def _searchIMDb(self, kind, ton, title_kind=None):
         """Search the IMDb akas server for the given title or name."""
         # The Exact Primary search system has gone AWOL, so we resort
         # to the mobile search. :-/
@@ -853,18 +853,36 @@ class IMDbBase:
         # exact match.
         if len(searchRes) == 1:
             return searchRes[0].getID()
+        title_only_matches = []
         for item in searchRes:
             # Return the first perfect match.
             if item[check] == ton:
-                return item.getID()
+                # For titles do additional check for kind
+                if kind != 'tt' or title_kind == item['kind']:
+                    return item.getID()
+                elif kind == 'tt':
+                    title_only_matches.append(item.getID())
+        # imdbpy2sql.py could detected wrong type, so if no title and kind
+        # matches found - collect all results with title only match
+        # Return list of IDs if multiple matches (can happen when searching
+        # titles with no title_kind specified)
+        # Example: DB: Band of Brothers "tv series" vs "tv mini-series"
+        if title_only_matches:
+            if len(title_only_matches) == 1:
+                return title_only_matches[0]
+            else:
+                return title_only_matches
         return None
 
-    def title2imdbID(self, title):
+    def title2imdbID(self, title, kind=None):
         """Translate a movie title (in the plain text data files format)
         to an imdbID.
         Try an Exact Primary Title search on IMDb;
-        return None if it's unable to get the imdbID."""
-        return self._searchIMDb('tt', title)
+        return None if it's unable to get the imdbID;
+        Always specify kind: movie, tv series, video game etc. or search can
+        return list of IDs if multiple matches found
+        """
+        return self._searchIMDb('tt', title, kind)
 
     def name2imdbID(self, name):
         """Translate a person name in an imdbID.
@@ -897,7 +915,7 @@ class IMDbBase:
                 imdbID = aSystem.get_imdbMovieID(mop.movieID)
             else:
                 imdbID = aSystem.title2imdbID(build_title(mop, canonical=0,
-                                                ptdf=1))
+                                                ptdf=0), mop['kind'])
         elif isinstance(mop, Person.Person):
             if mop.personID is not None:
                 imdbID = aSystem.get_imdbPersonID(mop.personID)

--- a/imdb/parser/sql/__init__.py
+++ b/imdb/parser/sql/__init__.py
@@ -831,7 +831,7 @@ class IMDbSqlAccessSystem(IMDbBase):
         if imdbID is not None: return '%07d' % imdbID
         m_dict = get_movie_data(movie.id, self._kind)
         titline = build_title(m_dict, ptdf=0)
-        imdbID = self.title2imdbID(titline)
+        imdbID = self.title2imdbID(titline, m_dict['kind'])
         # If the imdbID was retrieved from the web and was not in the
         # database, update the database (ignoring errors, because it's
         # possibile that the current user has not update privileges).

--- a/imdb/utils.py
+++ b/imdb/utils.py
@@ -398,7 +398,7 @@ def analyze_title(title, canonical=None, canonicalSeries=None,
     elif title.endswith('(TV Short)'):
         kind = u'tv short'
         title = title[:-10].rstrip()
-    elif title.endswith('(mini)'):
+    elif title.endswith('(TV Mini-Series)'):
         kind = u'tv mini series'
         title = title[:-6].rstrip()
     elif title.endswith('(VG)'):
@@ -510,7 +510,7 @@ def _convertTime(title, fromPTDFtoWEB=1, _emptyString=u''):
 
 def build_title(title_dict, canonical=None, canonicalSeries=None,
                 canonicalEpisode=None, ptdf=0, lang=None, _doYear=1,
-                _emptyString=u''):
+                _emptyString=u'', appendKind=False):
     """Given a dictionary that represents a "long" IMDb title,
     return a string.
 
@@ -592,7 +592,7 @@ def build_title(title_dict, canonical=None, canonicalSeries=None,
             year = str(year)
         title += ' (%s' % year
         title += ')'
-    if kind:
+    if appendKind and kind:
         if kind == 'tv movie':
             title += ' (TV)'
         elif kind == 'video movie':


### PR DESCRIPTION
1) IMDB doesn't return any results anymore, if we add subtype suffixes like `(V)`, `(VG)`, `(TV)` etc.

If we remove suffix, then we get results, but we can't be sure it matched the right kind.
Therefore only one right solution came to my mind.

I added additional parameter to `title2imdbID(title, kind=None)`
Now we can perform search without suffix and when comparing additionally check if `title_kind == kind` from the result
Of course when using `get_imdbMovieID(ID)` this kind is pre-filled from DB value

We can't leave without additional checking because wrong ID can be found:

For example:
Perspectives (2011) (TV Series)
Perspectives (2011) (Video)
http://akas.imdb.com/find?q=Perspective+2011&s=tt

The same will fail for these entries:
Terminator 2: Judgment Day (1991)
Terminator 2: Judgment Day (1991) (Video Game)
http://akas.imdb.com/find?q=Terminator+2%3A+Judgment+Day&s=tt

Second line searches for both these examples will match the first and match wrong ID.

Note: To avoid mis-matches, this parameter should be required, not optional. But i didn't wanted to create backwards compatibility break, so i made it optional. However since now, if no title kind is specified, and multiple matches found, there will be list of matched IDs returned not first one. I think this is better that someone will get wrong ID. 

2) Imdb changed from `(mini)` to `(TV Mini-Series)` suffix
3) Imdb doesn't enclose TV series anymore
4) Now search does non-canonical search and compare
