### PR TITLE
Fix to enable reading from CSV files on MySQL

### DIFF
--- a/imdb/parser/sql/alchemyadapter.py
+++ b/imdb/parser/sql/alchemyadapter.py
@@ -466,6 +466,7 @@ class _AlchemyConnection(object):
 
 def setConnection(uri, tables, encoding='utf8', debug=False):
     """Set connection for every table."""
+    params = {'encoding': encoding}
     # FIXME: why on earth MySQL requires an additional parameter,
     #        is well beyond my understanding...
     if uri.startswith('mysql'):
@@ -474,7 +475,11 @@ def setConnection(uri, tables, encoding='utf8', debug=False):
         else:
             uri += '?'
         uri += 'charset=%s' % encoding
-    params = {'encoding': encoding}
+        
+        # On some server configurations, we will need to explictly enable
+        # loading data from local files
+        params['local_infile'] = 1
+   
     if debug:
         params['echo'] = True
     if uri.startswith('ibm_db'):

--- a/imdb/parser/sql/objectadapter.py
+++ b/imdb/parser/sql/objectadapter.py
@@ -182,6 +182,10 @@ def setConnection(uri, tables, encoding='utf8', debug=False):
         kw['use_unicode'] = 1
         #kw['sqlobject_encoding'] = encoding
         kw['charset'] = encoding
+
+        # On some server configurations, we will need to explictly enable
+        # loading data from local files
+        kw['local_infile'] = 1
     conn = connectionForURI(uri, **kw)
     conn.debug = debug
     # XXX: doesn't work and a work-around was put in imdbpy2sql.py;


### PR DESCRIPTION
I've recently been setting up the local variant of the database using imdbpy2sql.py, and I got errors like this:

```
ERROR: unable to import CSV file imdb_csv/imdb_csv/complete_cast.csv: (1148, 'The used command is not allowed with this MySQL version')
```

Rather than just file a bug report, I figured this was simple enough that I could fix myself. This patch set is a fix that seems to work; it simply adds the parameter `local_infile=1` when creating a MySQL connection. Unfortunately, I have to do this globally (i.e. for all MySQL connections used by imdbpy), but based on the documentation I don't see how this can do any harm. 

I have tested this using the SQLObject version, and I have looked into the code of both SQLObject and SQLAlchemy to ensure that this flag is recognized by both ORMs. This is my first ever pull request; I am submitting it in the hope that it will be helpful.
