### PR TITLE
Added a new http parser to parse a Persons's resume page

### DIFF
--- a/imdb/parser/http/__init__.py
+++ b/imdb/parser/http/__init__.py
@@ -726,6 +726,10 @@ class IMDbHTTPAccessSystem(IMDbBase):
         cont = self._retrieve(self.urls['person_main'] % personID + 'bio')
         return self.pProxy.bio_parser.parse(cont, getRefs=self._getRefs)
 
+    def get_person_resume(self, personID):
+        cont = self._retrieve(self.urls['person_main'] % personID + 'resume')
+        return self.pProxy.resume_parser.parse(cont, getRefs=self._getRefs)
+
     def get_person_awards(self, personID):
         cont = self._retrieve(self.urls['person_main'] % personID + 'awards')
         return self.pProxy.person_awards_parser.parse(cont)


### PR DESCRIPTION
This adds a new http parser that parse's the data from an actor's resume page. The resume can be accessed with the 'resume' key. Everything is taken in pretty raw format. Here is an example of a resume page http://www.imdb.com/name/nm5993268/resume?ref_=nm_ov_res