### PR TITLE
Make all initial tests pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@
 build/
 __pycache__
 dist/
-.idea/
-.cache/
-.tox/
+.idea
+.cache
+.tox

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -271,7 +271,8 @@ class DOMHTMLMovieParser(DOMParserBase):
                 ),
                 Attribute(
                     key='color info',
-                    path="./h5[starts-with(text(), 'Color')]/..//text()",
+                    path="./h5[starts-with(text(), 'Color')]/.."
+                         "/div[@class='info-content']//text()",
                     postprocess=makeSplitter('|')
                 ),
                 Attribute(
@@ -622,8 +623,6 @@ class DOMHTMLMovieParser(DOMParserBase):
                 del data['other akas']
             if nakas:
                 data['akas'] = nakas
-        if 'color info' in data:
-            data['color info'] = [x.replace('Color:', '', 1) for x in data['color info']]
         if 'runtimes' in data:
             data['runtimes'] = [x.replace(' min', '')
                                 for x in data['runtimes']]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,9 +62,23 @@ MOVIES = {
     'suspiria':         '0076786'   # multiple country runtimes
 }
 
+PEOPLE = {
+    'deni_gordon':   '0330139',  # no headshot
+    'fred_astaire':  '0000001',  # name with dates
+    'julia_roberts': '0000210',  # IMDb index
+    'keanu_reeves':  '0000206'   # no IMDb index
+}
+
 
 @fixture(scope='session')
 def movies():
     """Base addresses of all test movies."""
     return {k: '%(base)s/title/tt%(key)s' % {'base': BASE_URL, 'key': v}
             for k, v in MOVIES.items()}
+
+
+@fixture(scope='session')
+def people():
+    """Base addresses of all test people."""
+    return {k: '%(base)s/name/nm%(key)s' % {'base': BASE_URL, 'key': v}
+            for k, v in PEOPLE.items()}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,28 +36,30 @@ urllib.request.urlopen = mock.Mock(wraps=mock_urlopen)
 BASE_URL = 'http://akas.imdb.com'
 
 MOVIES = {
-    'ace_in_the_hole':  '0043338',  # multiple languages
-    'aslan':            '3629794',  # no cover url
-    'ates_parcasi':     '1863157',  # no rating, no votes, no rank, no plot, no mpaa
-    'band_of_brothers': '0185906',  # tv mini-series, ended series years
+    'ace_in_the_hole':  '0043338',  # multiple languages, single sound mix with note
+    'aslan':            '3629794',  # no cover URL
+    'ates_parcasi':     '1863157',  # no rating, no votes, no rank, no plot, no mpaa,
+                                    # no aspect ratio, no sound mix
+    'band_of_brothers': '0185906',  # TV mini-series, ended series years
     'band_ep4':         '1247467',  # episode in mini-series
-    'dr_who':           '0436992',  # tv series, continuing series years
-    'dr_who_blink':     '1000252',  # tv episode
+    'dr_who':           '0436992',  # TV series, continuing series years
+    'dr_who_blink':     '1000252',  # TV episode
     'house':            '0412142',  # multiple seasons
     'house_first':      '0606035',  # first episode
     'house_middle':     '2121964',  # intermediate episode
     'house_last':       '2121965',  # last episode
-    'if':               '0063850',  # one genre, multiple color info with notes
+    'if':               '0063850',  # one genre, multiple color info with notes,
+                                    # single sound mix without notes
     'manos':            '0060666',  # bottom 100, single color info with notes
-    'matrix':           '0133093',  # top 250
+    'matrix':           '0133093',  # top 250, aspect ratio, multiple sound mix with notes
     'matrix_short':     '2971344',  # short movie, language "None"
-    'matrix_tv':        '0389150',  # tv movie, no color info
-    'matrix_tv_short':  '0274085',  # tv short movie
+    'matrix_tv':        '0389150',  # TV movie, no color info
+    'matrix_tv_short':  '0274085',  # TV short movie
     'matrix_vg':        '0390244',  # video game
     'matrix_video':     '0109151',  # video movie
     'mothers_day4':     '3698420',  # IMDb index
-    'pleasantville':    '0120789',  # multiple color info
-    'roast_sheen':      '1985970',  # tv special
+    'pleasantville':    '0120789',  # multiple color info, multiple sound mix without notes
+    'roast_sheen':      '1985970',  # TV special
     'shining':          '0081505',  # multiple runtimes, multiple countries
     'suspiria':         '0076786'   # multiple country runtimes
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import os
 import urllib.request
 from hashlib import md5
 from io import BytesIO
-from urllib.request import urlopen as urlopen_orig
+from urllib.request import urlopen as orig_urlopen
 
 
 logging.raiseExceptions = False
@@ -20,13 +20,13 @@ if not os.path.exists(cache_dir):
 def mock_urlopen(url):
     key = md5(url.encode('utf-8')).hexdigest()
     cache_file = os.path.join(cache_dir, key)
-    if not os.path.exists(cache_file):
-        content = urlopen_orig(url).read()
-        with open(cache_file, 'wb') as f:
-            f.write(content)
-    else:
+    if os.path.exists(cache_file):
         with open(cache_file, 'rb') as f:
             content = f.read()
+    else:
+        content = orig_urlopen(url).read()
+        with open(cache_file, 'wb') as f:
+            f.write(content)
     return BytesIO(content)
 
 

--- a/tests/test_http_movie_combined.py
+++ b/tests/test_http_movie_combined.py
@@ -18,7 +18,7 @@ def movie_combined_details(movies):
 parser = DOMHTMLMovieParser()
 
 
-def test_cover_url_should_be_link(movie_combined_details):
+def test_cover_url_should_be_a_link(movie_combined_details):
     page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
     assert data['cover url'].endswith('.jpg')

--- a/tests/test_http_movie_combined.py
+++ b/tests/test_http_movie_combined.py
@@ -526,13 +526,13 @@ def test_colors_multiple_should_be_a_list_of_color_types(movie_combined_details)
     assert data['color info'] == ['Black and White', 'Color']
 
 
-def test_colors_with_notes_single_should_include_notes(movie_combined_details):
+def test_colors_single_with_notes_should_include_notes(movie_combined_details):
     page = movie_combined_details('manos')
     data = parser.parse(page)['data']
     assert data['color info'] == ['Color::(Eastmancolor)']
 
 
-def test_colors_with_notes_multiple_should_include_notes(movie_combined_details):
+def test_colors_multiple_with_notes_should_include_notes(movie_combined_details):
     page = movie_combined_details('if')
     data = parser.parse(page)['data']
     assert data['color info'] == ['Black and White', 'Color::(Eastmancolor) (uncredited)']
@@ -542,3 +542,45 @@ def test_colors_none_should_be_excluded(movie_combined_details):
     page = movie_combined_details('matrix_tv')
     data = parser.parse(page)['data']
     assert 'color info' not in data
+
+
+def test_aspect_ratio_should_be_a_number_to_one(movie_combined_details):
+    page = movie_combined_details('matrix')
+    data = parser.parse(page)['data']
+    assert data['aspect ratio'] == '2.39 : 1'
+
+
+def test_aspect_ratio_none_should_be_excluded(movie_combined_details):
+    page = movie_combined_details('ates_parcasi')
+    data = parser.parse(page)['data']
+    assert 'aspect ratio' not in data
+
+
+def test_sound_mix_single_should_be_a_list_of_sound_mix_types(movie_combined_details):
+    page = movie_combined_details('if')
+    data = parser.parse(page)['data']
+    assert data['sound mix'] == ['Mono']
+
+
+def test_sound_mix_multiple_should_be_a_list_of_sound_mix_types(movie_combined_details):
+    page = movie_combined_details('pleasantville')
+    data = parser.parse(page)['data']
+    assert data['sound mix'] == ['DTS', 'Dolby Digital', 'SDDS']
+
+
+def test_sound_mix_single_with_notes_should_include_notes(movie_combined_details):
+    page = movie_combined_details('ace_in_the_hole')
+    data = parser.parse(page)['data']
+    assert data['sound mix'] == ['Mono::(Western Electric Recording)']
+
+
+def test_sound_mix_multiple_with_notes_should_include_notes(movie_combined_details):
+    page = movie_combined_details('matrix')
+    data = parser.parse(page)['data']
+    assert data['sound mix'] == ['DTS::(Digital DTS Sound)', 'Dolby Digital', 'SDDS']
+
+
+def test_sound_mix_none_should_be_excluded(movie_combined_details):
+    page = movie_combined_details('ates_parcasi')
+    data = parser.parse(page)['data']
+    assert 'sound mix' not in data

--- a/tests/test_http_movie_combined.py
+++ b/tests/test_http_movie_combined.py
@@ -304,10 +304,11 @@ def test_rank_none_should_be_excluded(movie_combined_details):
     assert 'bottom 100 rank' not in data
 
 
+@mark.fragile
 def test_series_season_titles_should_be_a_list_of_season_titles(movie_combined_details):
     page = get_document(movie_combined_details['dr_who'])
     data = parser.parse(page)['data']
-    assert data['seasons'] == [str(i) for i in range(1, 11)] + ['unknown']
+    assert data['seasons'] == [str(i) for i in range(1, 12)] + ['unknown']
 
 
 def test_series_season_titles_none_should_be_excluded(movie_combined_details):
@@ -326,7 +327,7 @@ def test_series_number_of_seasons_numeric_should_be_ok(movie_combined_details):
 def test_series_number_of_seasons_should_exclude_non_numeric_season_titles(movie_combined_details):
     page = get_document(movie_combined_details['dr_who'])
     data = parser.parse(page)['data']
-    assert data['number of seasons'] == 10
+    assert data['number of seasons'] == 11
 
 
 def test_original_air_date_should_be_a_date(movie_combined_details):

--- a/tests/test_http_movie_combined.py
+++ b/tests/test_http_movie_combined.py
@@ -6,239 +6,237 @@ from urllib.request import urlopen
 from imdb.parser.http.movieParser import DOMHTMLMovieParser
 
 
-def get_page(url):
-    content = urlopen(url).read()
-    return content.decode('utf-8')
-
-
 @fixture(scope='module')
 def movie_combined_details(movies):
     """Combined details page addresses of all test movies."""
-    return {k: v + '/combined' for k, v in movies.items()}
+    def retrieve(movie_key):
+        url = movies[movie_key] + '/combined'
+        return urlopen(url).read().decode('utf-8')
+    return retrieve
 
 
 parser = DOMHTMLMovieParser()
 
 
 def test_cover_url_should_be_link(movie_combined_details):
-    page = get_page(movie_combined_details['matrix'])
+    page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
     assert data['cover url'].endswith('.jpg')
 
 
 def test_cover_url_none_should_be_excluded(movie_combined_details):
-    page = get_page(movie_combined_details['aslan'])
+    page = movie_combined_details('aslan')
     data = parser.parse(page)['data']
     assert 'cover url' not in data
 
 
 def test_title_should_not_have_year(movie_combined_details):
-    page = get_page(movie_combined_details['matrix'])
+    page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
     assert data['title'] == 'The Matrix'
 
 
 def test_title_tv_movie_should_not_include_type(movie_combined_details):
-    page = get_page(movie_combined_details['matrix_tv'])
+    page = movie_combined_details('matrix_tv')
     data = parser.parse(page)['data']
     assert data['title'] == 'The Matrix Defence'
 
 
 def test_title_video_movie_should_not_include_type(movie_combined_details):
-    page = get_page(movie_combined_details['matrix_video'])
+    page = movie_combined_details('matrix_video')
     data = parser.parse(page)['data']
     assert data['title'] == 'Armitage III: Poly Matrix'
 
 
 def test_title_video_game_should_not_include_type(movie_combined_details):
-    page = get_page(movie_combined_details['matrix_vg'])
+    page = movie_combined_details('matrix_vg')
     data = parser.parse(page)['data']
     assert data['title'] == 'The Matrix Online'
 
 
 def test_title_tv_series_should_not_have_quotes(movie_combined_details):
-    page = get_page(movie_combined_details['dr_who'])
+    page = movie_combined_details('dr_who')
     data = parser.parse(page)['data']
     assert data['title'] == 'Doctor Who'
 
 
 def test_title_tv_mini_series_should_not_have_quotes(movie_combined_details):
-    page = get_page(movie_combined_details['band_of_brothers'])
+    page = movie_combined_details('band_of_brothers')
     data = parser.parse(page)['data']
     assert data['title'] == 'Band of Brothers'
 
 
 def test_title_tv_episode_should_not_be_series_title(movie_combined_details):
-    page = get_page(movie_combined_details['dr_who_blink'])
+    page = movie_combined_details('dr_who_blink')
     data = parser.parse(page)['data']
     assert data['title'] == 'Blink'
 
 
 def test_year_should_be_an_integer(movie_combined_details):
-    page = get_page(movie_combined_details['matrix'])
+    page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
     assert data['year'] == 1999
 
 
 def test_year_followed_by_kind_in_full_title_should_be_ok(movie_combined_details):
-    page = get_page(movie_combined_details['matrix_video'])
+    page = movie_combined_details('matrix_video')
     data = parser.parse(page)['data']
     assert data['year'] == 1996
 
 
 def test_year_none_should_be_excluded(movie_combined_details):
-    page = get_page(movie_combined_details['aslan'])
+    page = movie_combined_details('aslan')
     data = parser.parse(page)['data']
     assert 'year' not in data
 
 
 def test_imdb_index_should_be_a_roman_number(movie_combined_details):
-    page = get_page(movie_combined_details['mothers_day4'])
+    page = movie_combined_details('mothers_day4')
     data = parser.parse(page)['data']
     assert data['imdbIndex'] == 'IV'
 
 
 def test_imdb_index_none_should_be_excluded(movie_combined_details):
-    page = get_page(movie_combined_details['matrix'])
+    page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
     assert 'imdbIndex' not in data
 
 
 def test_kind_none_should_be_movie(movie_combined_details):
-    page = get_page(movie_combined_details['matrix'])
+    page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
     assert data['kind'] == 'movie'
 
 
 def test_kind_tv_movie_should_be_tv_movie(movie_combined_details):
-    page = get_page(movie_combined_details['matrix_tv'])
+    page = movie_combined_details('matrix_tv')
     data = parser.parse(page)['data']
     assert data['kind'] == 'tv movie'
 
 
 def test_kind_video_movie_should_be_video_movie(movie_combined_details):
-    page = get_page(movie_combined_details['matrix_video'])
+    page = movie_combined_details('matrix_video')
     data = parser.parse(page)['data']
     assert data['kind'] == 'video movie'
 
 
 def test_kind_video_game_should_be_video_game(movie_combined_details):
-    page = get_page(movie_combined_details['matrix_vg'])
+    page = movie_combined_details('matrix_vg')
     data = parser.parse(page)['data']
     assert data['kind'] == 'video game'
 
 
 def test_kind_tv_series_should_be_tv_series(movie_combined_details):
-    page = get_page(movie_combined_details['dr_who'])
+    page = movie_combined_details('dr_who')
     data = parser.parse(page)['data']
     assert data['kind'] == 'tv series'
 
 
 def test_kind_tv_mini_series_should_be_tv_mini_series(movie_combined_details):
-    page = get_page(movie_combined_details['band_of_brothers'])
+    page = movie_combined_details('band_of_brothers')
     data = parser.parse(page)['data']
     assert data['kind'] == 'tv mini series'
 
 
 def test_kind_tv_series_episode_should_be_episode(movie_combined_details):
-    page = get_page(movie_combined_details['dr_who_blink'])
+    page = movie_combined_details('dr_who_blink')
     data = parser.parse(page)['data']
     assert data['kind'] == 'episode'
 
 
 # def test_kind_short_movie_should_be_short_movie(movie_combined_details):
-#     page = get_page(movie_combined_details['matrix_short'])
+#     page = movie_combined_details('matrix_short')
 #     data = parser.parse(page)['data']
 #     assert data['kind'] == 'short movie'
 
 
 # def test_kind_tv_short_movie_should_be_tv_short_movie(movie_combined_details):
-#     page = get_page(movie_combined_details['matrix_tv_short'])
+#     page = movie_combined_details('matrix_tv_short')
 #     data = parser.parse(page)['data']
 #     assert data['kind'] == 'tv short movie'
 
 
 # def test_kind_tv_special_should_be_tv_special(movie_combined_details):
-#     page = get_page(movie_combined_details['roast_sheen'])
+#     page = movie_combined_details('roast_sheen')
 #     data = parser.parse(page)['data']
 #     assert data['kind'] == 'tv special'
 
 
 @mark.fragile
 def test_series_years_continuing_should_be_open_range(movie_combined_details):
-    page = get_page(movie_combined_details['dr_who'])
+    page = movie_combined_details('dr_who')
     data = parser.parse(page)['data']
     assert data['series years'] == '2005-'
 
 
 def test_series_years_ended_should_be_closed_range(movie_combined_details):
-    page = get_page(movie_combined_details['house'])
+    page = movie_combined_details('house')
     data = parser.parse(page)['data']
     assert data['series years'] == '2004-2012'
 
 
 def test_series_years_mini_series_ended_in_same_year_should_be_closed_range(movie_combined_details):
-    page = get_page(movie_combined_details['band_of_brothers'])
+    page = movie_combined_details('band_of_brothers')
     data = parser.parse(page)['data']
     assert data['series years'] == '2001-2001'
 
 
 def test_series_years_none_should_be_excluded(movie_combined_details):
-    page = get_page(movie_combined_details['dr_who_blink'])
+    page = movie_combined_details('dr_who_blink')
     data = parser.parse(page)['data']
     assert 'series years' not in data
 
 
 def test_number_of_episodes_should_be_an_integer(movie_combined_details):
-    page = get_page(movie_combined_details['house_middle'])
+    page = movie_combined_details('house_middle')
     data = parser.parse(page)['data']
     assert data['number of episodes'] == 176
 
 
 def test_number_of_episodes_none_should_be_excluded(movie_combined_details):
-    page = get_page(movie_combined_details['house'])
+    page = movie_combined_details('house')
     data = parser.parse(page)['data']
     assert 'number of episodes' not in data
 
 
 def test_episode_number_should_be_an_integer(movie_combined_details):
-    page = get_page(movie_combined_details['house_middle'])
+    page = movie_combined_details('house_middle')
     data = parser.parse(page)['data']
     assert data['episode number'] == 175
 
 
 def test_episode_number_none_should_be_excluded(movie_combined_details):
-    page = get_page(movie_combined_details['house'])
+    page = movie_combined_details('house')
     data = parser.parse(page)['data']
     assert 'episode number' not in data
 
 
 def test_previous_episode_should_be_an_imdb_id(movie_combined_details):
-    page = get_page(movie_combined_details['house_middle'])
+    page = movie_combined_details('house_middle')
     data = parser.parse(page)['data']
     assert data['previous episode'] == '2121963'
 
 
 def test_previous_episode_none_should_be_excluded(movie_combined_details):
-    page = get_page(movie_combined_details['house_first'])
+    page = movie_combined_details('house_first')
     data = parser.parse(page)['data']
     assert 'previous episode' not in data
 
 
 def test_next_episode_should_be_an_imdb_id(movie_combined_details):
-    page = get_page(movie_combined_details['house_middle'])
+    page = movie_combined_details('house_middle')
     data = parser.parse(page)['data']
     assert data['next episode'] == '2121965'
 
 
 def test_next_episode_none_should_be_excluded(movie_combined_details):
-    page = get_page(movie_combined_details['house_last'])
+    page = movie_combined_details('house_last')
     data = parser.parse(page)['data']
     assert 'next episode' not in data
 
 
 def test_episode_of_series_should_have_title_year_and_kind(movie_combined_details):
-    page = get_page(movie_combined_details['house_middle'])
+    page = movie_combined_details('house_middle')
     data = parser.parse(page)['data']
     series = data['episode of']
     assert series.movieID == '0412142'
@@ -246,7 +244,7 @@ def test_episode_of_series_should_have_title_year_and_kind(movie_combined_detail
 
 
 def test_episode_of_mini_series_should_have_kind_tv_series(movie_combined_details):
-    page = get_page(movie_combined_details['band_ep4'])
+    page = movie_combined_details('band_ep4')
     data = parser.parse(page)['data']
     series = data['episode of']
     assert series.movieID == '0185906'
@@ -254,51 +252,51 @@ def test_episode_of_mini_series_should_have_kind_tv_series(movie_combined_detail
 
 
 def test_episode_of_series_none_should_be_excluded(movie_combined_details):
-    page = get_page(movie_combined_details['house'])
+    page = movie_combined_details('house')
     data = parser.parse(page)['data']
     assert 'episode of' not in data
 
 
 def test_rating_should_be_between_1_and_10(movie_combined_details):
-    page = get_page(movie_combined_details['matrix'])
+    page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
     assert 1.0 <= data['rating'] <= 10.0
 
 
 def test_rating_none_should_be_excluded(movie_combined_details):
-    page = get_page(movie_combined_details['ates_parcasi'])
+    page = movie_combined_details('ates_parcasi')
     data = parser.parse(page)['data']
     assert 'rating' not in data
 
 
 def test_votes_should_be_an_integer(movie_combined_details):
-    page = get_page(movie_combined_details['matrix'])
+    page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
     assert data['votes'] > 1000000
 
 
 def test_votes_none_should_be_excluded(movie_combined_details):
-    page = get_page(movie_combined_details['ates_parcasi'])
+    page = movie_combined_details('ates_parcasi')
     data = parser.parse(page)['data']
     assert 'votes' not in data
 
 
 @mark.fragile
 def test_rank_top250_should_be_between_1_and_250(movie_combined_details):
-    page = get_page(movie_combined_details['matrix'])
+    page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
     assert 1 <= data['top 250 rank'] <= 250
 
 
 @mark.fragile
 def test_rank_bottom100_should_be_between_1_and_100(movie_combined_details):
-    page = get_page(movie_combined_details['manos'])
+    page = movie_combined_details('manos')
     data = parser.parse(page)['data']
     assert 1 <= data['bottom 100 rank'] <= 100
 
 
 def test_rank_none_should_be_excluded(movie_combined_details):
-    page = get_page(movie_combined_details['ates_parcasi'])
+    page = movie_combined_details('ates_parcasi')
     data = parser.parse(page)['data']
     assert 'top 250 rank' not in data
     assert 'bottom 100 rank' not in data
@@ -306,64 +304,64 @@ def test_rank_none_should_be_excluded(movie_combined_details):
 
 @mark.fragile
 def test_series_season_titles_should_be_a_list_of_season_titles(movie_combined_details):
-    page = get_page(movie_combined_details['dr_who'])
+    page = movie_combined_details('dr_who')
     data = parser.parse(page)['data']
     assert data['seasons'] == [str(i) for i in range(1, 12)] + ['unknown']
 
 
 def test_series_season_titles_none_should_be_excluded(movie_combined_details):
-    page = get_page(movie_combined_details['dr_who_blink'])
+    page = movie_combined_details('dr_who_blink')
     data = parser.parse(page)['data']
     assert 'seasons' not in data
 
 
 def test_series_number_of_seasons_numeric_should_be_ok(movie_combined_details):
-    page = get_page(movie_combined_details['house'])
+    page = movie_combined_details('house')
     data = parser.parse(page)['data']
     assert data['number of seasons'] == 8
 
 
 @mark.fragile
 def test_series_number_of_seasons_should_exclude_non_numeric_season_titles(movie_combined_details):
-    page = get_page(movie_combined_details['dr_who'])
+    page = movie_combined_details('dr_who')
     data = parser.parse(page)['data']
     assert data['number of seasons'] == 11
 
 
 def test_original_air_date_should_be_a_date(movie_combined_details):
-    page = get_page(movie_combined_details['dr_who_blink'])
+    page = movie_combined_details('dr_who_blink')
     data = parser.parse(page)['data']
     assert data['original air date'] == '9 June 2007'
 
 
 def test_original_air_date_none_should_be_excluded(movie_combined_details):
-    page = get_page(movie_combined_details['dr_who'])
+    page = movie_combined_details('dr_who')
     data = parser.parse(page)['data']
     assert 'original air date' not in data
 
 
 def test_season_and_episode_numbers_should_be_integers(movie_combined_details):
-    page = get_page(movie_combined_details['dr_who_blink'])
+    page = movie_combined_details('dr_who_blink')
     data = parser.parse(page)['data']
     assert data['season'] == 3
     assert data['episode'] == 10
 
 
 def test_season_and_episode_numbers_none_should_be_excluded(movie_combined_details):
-    page = get_page(movie_combined_details['dr_who'])
+    page = movie_combined_details('dr_who')
     data = parser.parse(page)['data']
     assert 'season' not in data
     assert 'episode' not in data
 
 
 def test_genres_single_should_be_a_list_of_genre_names(movie_combined_details):
-    page = get_page(movie_combined_details['if'])
+    page = movie_combined_details('if')
     data = parser.parse(page)['data']
     assert data['genres'] == ['Drama']
 
 
 def test_genres_multiple_should_be_a_list_of_genre_names(movie_combined_details):
-    page = get_page(movie_combined_details['matrix'])
+    page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
     assert data['genres'] == ['Action', 'Sci-Fi']
 
@@ -376,43 +374,43 @@ def test_genres_multiple_should_be_a_list_of_genre_names(movie_combined_details)
 
 
 def test_plot_outline_should_be_a_longer_text(movie_combined_details):
-    page = get_page(movie_combined_details['matrix'])
+    page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
     assert re.match('^A computer hacker .* against its controllers.$', data['plot outline'])
 
 
 def test_plot_outline_none_should_be_excluded(movie_combined_details):
-    page = get_page(movie_combined_details['ates_parcasi'])
+    page = movie_combined_details('ates_parcasi')
     data = parser.parse(page)['data']
     assert 'plot outline' not in data
 
 
 def test_mpaa_should_be_a_rating(movie_combined_details):
-    page = get_page(movie_combined_details['matrix'])
+    page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
     assert data['mpaa'] == 'Rated R for sci-fi violence and brief language'
 
 
 def test_mpaa_none_should_be_excluded(movie_combined_details):
-    page = get_page(movie_combined_details['ates_parcasi'])
+    page = movie_combined_details('ates_parcasi')
     data = parser.parse(page)['data']
     assert 'mpaa' not in data
 
 
 def test_runtimes_single_should_be_a_list_in_minutes(movie_combined_details):
-    page = get_page(movie_combined_details['matrix'])
+    page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
     assert data['runtimes'] == ['136']
 
 
 def test_runtimes_with_countries_should_include_context(movie_combined_details):
-    page = get_page(movie_combined_details['suspiria'])
+    page = movie_combined_details('suspiria')
     data = parser.parse(page)['data']
     assert data['runtimes'] == ['98', 'Germany:88', 'USA:92', 'Argentina:95']
 
 
 def test_runtimes_multiple_with_notes_should_include_notes(movie_combined_details):
-    page = get_page(movie_combined_details['shining'])
+    page = movie_combined_details('shining')
     data = parser.parse(page)['data']
     assert data['runtimes'] == [
         '144::(cut)',
@@ -423,19 +421,19 @@ def test_runtimes_multiple_with_notes_should_include_notes(movie_combined_detail
 
 
 def test_runtimes_none_should_be_excluded(movie_combined_details):
-    page = get_page(movie_combined_details['matrix_vg'])
+    page = movie_combined_details('matrix_vg')
     data = parser.parse(page)['data']
     assert 'runtimes' not in data
 
 
 def test_countries_single_should_be_a_list_of_country_names(movie_combined_details):
-    page = get_page(movie_combined_details['matrix'])
+    page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
     assert data['countries'] == ['USA']
 
 
 def test_countries_multiple_should_be_a_list_of_country_names(movie_combined_details):
-    page = get_page(movie_combined_details['shining'])
+    page = movie_combined_details('shining')
     data = parser.parse(page)['data']
     assert data['countries'] == ['UK', 'USA']
 
@@ -448,13 +446,13 @@ def test_countries_multiple_should_be_a_list_of_country_names(movie_combined_det
 
 
 def test_country_codes_single_should_be_a_list_of_country_codes(movie_combined_details):
-    page = get_page(movie_combined_details['matrix'])
+    page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
     assert data['country codes'] == ['us']
 
 
 def test_country_codes_multiple_should_be_a_list_of_country_codes(movie_combined_details):
-    page = get_page(movie_combined_details['shining'])
+    page = movie_combined_details('shining')
     data = parser.parse(page)['data']
     assert data['country codes'] == ['gb', 'us']
 
@@ -467,19 +465,19 @@ def test_country_codes_multiple_should_be_a_list_of_country_codes(movie_combined
 
 
 def test_languages_single_should_be_a_list_of_language_names(movie_combined_details):
-    page = get_page(movie_combined_details['matrix'])
+    page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
     assert data['languages'] == ['English']
 
 
 def test_languages_multiple_should_be_a_list_of_language_names(movie_combined_details):
-    page = get_page(movie_combined_details['ace_in_the_hole'])
+    page = movie_combined_details('ace_in_the_hole')
     data = parser.parse(page)['data']
     assert data['languages'] == ['English', 'Spanish', 'Latin']
 
 
 def test_languages_single_none_as_a_language_name_should_be_valid(movie_combined_details):
-    page = get_page(movie_combined_details['matrix_short'])
+    page = movie_combined_details('matrix_short')
     data = parser.parse(page)['data']
     assert data['languages'] == ['None']
 
@@ -492,19 +490,19 @@ def test_languages_single_none_as_a_language_name_should_be_valid(movie_combined
 
 
 def test_language_codes_single_should_be_a_list_of_language_names(movie_combined_details):
-    page = get_page(movie_combined_details['matrix'])
+    page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
     assert data['language codes'] == ['en']
 
 
 def test_language_codes_multiple_should_be_a_list_of_language_names(movie_combined_details):
-    page = get_page(movie_combined_details['ace_in_the_hole'])
+    page = movie_combined_details('ace_in_the_hole')
     data = parser.parse(page)['data']
     assert data['language codes'] == ['en', 'es', 'la']
 
 
 def test_language_codes_single_none_as_a_language_name_should_be_valid(movie_combined_details):
-    page = get_page(movie_combined_details['matrix_short'])
+    page = movie_combined_details('matrix_short')
     data = parser.parse(page)['data']
     assert data['language codes'] == ['zxx']
 
@@ -517,30 +515,30 @@ def test_language_codes_single_none_as_a_language_name_should_be_valid(movie_com
 
 
 def test_colors_single_should_be_a_list_of_color_types(movie_combined_details):
-    page = get_page(movie_combined_details['matrix'])
+    page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
     assert data['color info'] == ['Color']
 
 
 def test_colors_multiple_should_be_a_list_of_color_types(movie_combined_details):
-    page = get_page(movie_combined_details['pleasantville'])
+    page = movie_combined_details('pleasantville')
     data = parser.parse(page)['data']
     assert data['color info'] == ['Black and White', 'Color']
 
 
 def test_colors_with_notes_single_should_include_notes(movie_combined_details):
-    page = get_page(movie_combined_details['manos'])
+    page = movie_combined_details('manos')
     data = parser.parse(page)['data']
     assert data['color info'] == ['Color::(Eastmancolor)']
 
 
 def test_colors_with_notes_multiple_should_include_notes(movie_combined_details):
-    page = get_page(movie_combined_details['if'])
+    page = movie_combined_details('if')
     data = parser.parse(page)['data']
     assert data['color info'] == ['Black and White', 'Color::(Eastmancolor) (uncredited)']
 
 
 def test_colors_none_should_be_excluded(movie_combined_details):
-    page = get_page(movie_combined_details['matrix_tv'])
+    page = movie_combined_details('matrix_tv')
     data = parser.parse(page)['data']
     assert 'color info' not in data

--- a/tests/test_http_movie_combined.py
+++ b/tests/test_http_movie_combined.py
@@ -8,7 +8,7 @@ from imdb.parser.http.movieParser import DOMHTMLMovieParser
 
 @fixture(scope='module')
 def movie_combined_details(movies):
-    """Combined details page addresses of all test movies."""
+    """A function to retrieve the combined details page of a test movie."""
     def retrieve(movie_key):
         url = movies[movie_key] + '/combined'
         return urlopen(url).read().decode('utf-8')

--- a/tests/test_http_movie_combined.py
+++ b/tests/test_http_movie_combined.py
@@ -6,7 +6,7 @@ from urllib.request import urlopen
 from imdb.parser.http.movieParser import DOMHTMLMovieParser
 
 
-def get_document(url):
+def get_page(url):
     content = urlopen(url).read()
     return content.decode('utf-8')
 
@@ -21,224 +21,224 @@ parser = DOMHTMLMovieParser()
 
 
 def test_cover_url_should_be_link(movie_combined_details):
-    page = get_document(movie_combined_details['matrix'])
+    page = get_page(movie_combined_details['matrix'])
     data = parser.parse(page)['data']
     assert data['cover url'].endswith('.jpg')
 
 
 def test_cover_url_none_should_be_excluded(movie_combined_details):
-    page = get_document(movie_combined_details['aslan'])
+    page = get_page(movie_combined_details['aslan'])
     data = parser.parse(page)['data']
     assert 'cover url' not in data
 
 
 def test_title_should_not_have_year(movie_combined_details):
-    page = get_document(movie_combined_details['matrix'])
+    page = get_page(movie_combined_details['matrix'])
     data = parser.parse(page)['data']
     assert data['title'] == 'The Matrix'
 
 
 def test_title_tv_movie_should_not_include_type(movie_combined_details):
-    page = get_document(movie_combined_details['matrix_tv'])
+    page = get_page(movie_combined_details['matrix_tv'])
     data = parser.parse(page)['data']
     assert data['title'] == 'The Matrix Defence'
 
 
 def test_title_video_movie_should_not_include_type(movie_combined_details):
-    page = get_document(movie_combined_details['matrix_video'])
+    page = get_page(movie_combined_details['matrix_video'])
     data = parser.parse(page)['data']
     assert data['title'] == 'Armitage III: Poly Matrix'
 
 
 def test_title_video_game_should_not_include_type(movie_combined_details):
-    page = get_document(movie_combined_details['matrix_vg'])
+    page = get_page(movie_combined_details['matrix_vg'])
     data = parser.parse(page)['data']
     assert data['title'] == 'The Matrix Online'
 
 
 def test_title_tv_series_should_not_have_quotes(movie_combined_details):
-    page = get_document(movie_combined_details['dr_who'])
+    page = get_page(movie_combined_details['dr_who'])
     data = parser.parse(page)['data']
     assert data['title'] == 'Doctor Who'
 
 
 def test_title_tv_mini_series_should_not_have_quotes(movie_combined_details):
-    page = get_document(movie_combined_details['band_of_brothers'])
+    page = get_page(movie_combined_details['band_of_brothers'])
     data = parser.parse(page)['data']
     assert data['title'] == 'Band of Brothers'
 
 
 def test_title_tv_episode_should_not_be_series_title(movie_combined_details):
-    page = get_document(movie_combined_details['dr_who_blink'])
+    page = get_page(movie_combined_details['dr_who_blink'])
     data = parser.parse(page)['data']
     assert data['title'] == 'Blink'
 
 
 def test_year_should_be_an_integer(movie_combined_details):
-    page = get_document(movie_combined_details['matrix'])
+    page = get_page(movie_combined_details['matrix'])
     data = parser.parse(page)['data']
     assert data['year'] == 1999
 
 
 def test_year_followed_by_kind_in_full_title_should_be_ok(movie_combined_details):
-    page = get_document(movie_combined_details['matrix_video'])
+    page = get_page(movie_combined_details['matrix_video'])
     data = parser.parse(page)['data']
     assert data['year'] == 1996
 
 
 def test_year_none_should_be_excluded(movie_combined_details):
-    page = get_document(movie_combined_details['aslan'])
+    page = get_page(movie_combined_details['aslan'])
     data = parser.parse(page)['data']
     assert 'year' not in data
 
 
 def test_imdb_index_should_be_a_roman_number(movie_combined_details):
-    page = get_document(movie_combined_details['mothers_day4'])
+    page = get_page(movie_combined_details['mothers_day4'])
     data = parser.parse(page)['data']
     assert data['imdbIndex'] == 'IV'
 
 
 def test_imdb_index_none_should_be_excluded(movie_combined_details):
-    page = get_document(movie_combined_details['matrix'])
+    page = get_page(movie_combined_details['matrix'])
     data = parser.parse(page)['data']
     assert 'imdbIndex' not in data
 
 
 def test_kind_none_should_be_movie(movie_combined_details):
-    page = get_document(movie_combined_details['matrix'])
+    page = get_page(movie_combined_details['matrix'])
     data = parser.parse(page)['data']
     assert data['kind'] == 'movie'
 
 
 def test_kind_tv_movie_should_be_tv_movie(movie_combined_details):
-    page = get_document(movie_combined_details['matrix_tv'])
+    page = get_page(movie_combined_details['matrix_tv'])
     data = parser.parse(page)['data']
     assert data['kind'] == 'tv movie'
 
 
 def test_kind_video_movie_should_be_video_movie(movie_combined_details):
-    page = get_document(movie_combined_details['matrix_video'])
+    page = get_page(movie_combined_details['matrix_video'])
     data = parser.parse(page)['data']
     assert data['kind'] == 'video movie'
 
 
 def test_kind_video_game_should_be_video_game(movie_combined_details):
-    page = get_document(movie_combined_details['matrix_vg'])
+    page = get_page(movie_combined_details['matrix_vg'])
     data = parser.parse(page)['data']
     assert data['kind'] == 'video game'
 
 
 def test_kind_tv_series_should_be_tv_series(movie_combined_details):
-    page = get_document(movie_combined_details['dr_who'])
+    page = get_page(movie_combined_details['dr_who'])
     data = parser.parse(page)['data']
     assert data['kind'] == 'tv series'
 
 
 def test_kind_tv_mini_series_should_be_tv_mini_series(movie_combined_details):
-    page = get_document(movie_combined_details['band_of_brothers'])
+    page = get_page(movie_combined_details['band_of_brothers'])
     data = parser.parse(page)['data']
     assert data['kind'] == 'tv mini series'
 
 
 def test_kind_tv_series_episode_should_be_episode(movie_combined_details):
-    page = get_document(movie_combined_details['dr_who_blink'])
+    page = get_page(movie_combined_details['dr_who_blink'])
     data = parser.parse(page)['data']
     assert data['kind'] == 'episode'
 
 
 # def test_kind_short_movie_should_be_short_movie(movie_combined_details):
-#     page = get_document(movie_combined_details['matrix_short'])
+#     page = get_page(movie_combined_details['matrix_short'])
 #     data = parser.parse(page)['data']
 #     assert data['kind'] == 'short movie'
 
 
 # def test_kind_tv_short_movie_should_be_tv_short_movie(movie_combined_details):
-#     page = get_document(movie_combined_details['matrix_tv_short'])
+#     page = get_page(movie_combined_details['matrix_tv_short'])
 #     data = parser.parse(page)['data']
 #     assert data['kind'] == 'tv short movie'
 
 
 # def test_kind_tv_special_should_be_tv_special(movie_combined_details):
-#     page = get_document(movie_combined_details['roast_sheen'])
+#     page = get_page(movie_combined_details['roast_sheen'])
 #     data = parser.parse(page)['data']
 #     assert data['kind'] == 'tv special'
 
 
 @mark.fragile
 def test_series_years_continuing_should_be_open_range(movie_combined_details):
-    page = get_document(movie_combined_details['dr_who'])
+    page = get_page(movie_combined_details['dr_who'])
     data = parser.parse(page)['data']
     assert data['series years'] == '2005-'
 
 
 def test_series_years_ended_should_be_closed_range(movie_combined_details):
-    page = get_document(movie_combined_details['house'])
+    page = get_page(movie_combined_details['house'])
     data = parser.parse(page)['data']
     assert data['series years'] == '2004-2012'
 
 
 def test_series_years_mini_series_ended_in_same_year_should_be_closed_range(movie_combined_details):
-    page = get_document(movie_combined_details['band_of_brothers'])
+    page = get_page(movie_combined_details['band_of_brothers'])
     data = parser.parse(page)['data']
     assert data['series years'] == '2001-2001'
 
 
 def test_series_years_none_should_be_excluded(movie_combined_details):
-    page = get_document(movie_combined_details['dr_who_blink'])
+    page = get_page(movie_combined_details['dr_who_blink'])
     data = parser.parse(page)['data']
     assert 'series years' not in data
 
 
 def test_number_of_episodes_should_be_an_integer(movie_combined_details):
-    page = get_document(movie_combined_details['house_middle'])
+    page = get_page(movie_combined_details['house_middle'])
     data = parser.parse(page)['data']
     assert data['number of episodes'] == 176
 
 
 def test_number_of_episodes_none_should_be_excluded(movie_combined_details):
-    page = get_document(movie_combined_details['house'])
+    page = get_page(movie_combined_details['house'])
     data = parser.parse(page)['data']
     assert 'number of episodes' not in data
 
 
 def test_episode_number_should_be_an_integer(movie_combined_details):
-    page = get_document(movie_combined_details['house_middle'])
+    page = get_page(movie_combined_details['house_middle'])
     data = parser.parse(page)['data']
     assert data['episode number'] == 175
 
 
 def test_episode_number_none_should_be_excluded(movie_combined_details):
-    page = get_document(movie_combined_details['house'])
+    page = get_page(movie_combined_details['house'])
     data = parser.parse(page)['data']
     assert 'episode number' not in data
 
 
 def test_previous_episode_should_be_an_imdb_id(movie_combined_details):
-    page = get_document(movie_combined_details['house_middle'])
+    page = get_page(movie_combined_details['house_middle'])
     data = parser.parse(page)['data']
     assert data['previous episode'] == '2121963'
 
 
 def test_previous_episode_none_should_be_excluded(movie_combined_details):
-    page = get_document(movie_combined_details['house_first'])
+    page = get_page(movie_combined_details['house_first'])
     data = parser.parse(page)['data']
     assert 'previous episode' not in data
 
 
 def test_next_episode_should_be_an_imdb_id(movie_combined_details):
-    page = get_document(movie_combined_details['house_middle'])
+    page = get_page(movie_combined_details['house_middle'])
     data = parser.parse(page)['data']
     assert data['next episode'] == '2121965'
 
 
 def test_next_episode_none_should_be_excluded(movie_combined_details):
-    page = get_document(movie_combined_details['house_last'])
+    page = get_page(movie_combined_details['house_last'])
     data = parser.parse(page)['data']
     assert 'next episode' not in data
 
 
 def test_episode_of_series_should_have_title_year_and_kind(movie_combined_details):
-    page = get_document(movie_combined_details['house_middle'])
+    page = get_page(movie_combined_details['house_middle'])
     data = parser.parse(page)['data']
     series = data['episode of']
     assert series.movieID == '0412142'
@@ -246,7 +246,7 @@ def test_episode_of_series_should_have_title_year_and_kind(movie_combined_detail
 
 
 def test_episode_of_mini_series_should_have_kind_tv_series(movie_combined_details):
-    page = get_document(movie_combined_details['band_ep4'])
+    page = get_page(movie_combined_details['band_ep4'])
     data = parser.parse(page)['data']
     series = data['episode of']
     assert series.movieID == '0185906'
@@ -254,51 +254,51 @@ def test_episode_of_mini_series_should_have_kind_tv_series(movie_combined_detail
 
 
 def test_episode_of_series_none_should_be_excluded(movie_combined_details):
-    page = get_document(movie_combined_details['house'])
+    page = get_page(movie_combined_details['house'])
     data = parser.parse(page)['data']
     assert 'episode of' not in data
 
 
 def test_rating_should_be_between_1_and_10(movie_combined_details):
-    page = get_document(movie_combined_details['matrix'])
+    page = get_page(movie_combined_details['matrix'])
     data = parser.parse(page)['data']
     assert 1.0 <= data['rating'] <= 10.0
 
 
 def test_rating_none_should_be_excluded(movie_combined_details):
-    page = get_document(movie_combined_details['ates_parcasi'])
+    page = get_page(movie_combined_details['ates_parcasi'])
     data = parser.parse(page)['data']
     assert 'rating' not in data
 
 
 def test_votes_should_be_an_integer(movie_combined_details):
-    page = get_document(movie_combined_details['matrix'])
+    page = get_page(movie_combined_details['matrix'])
     data = parser.parse(page)['data']
     assert data['votes'] > 1000000
 
 
 def test_votes_none_should_be_excluded(movie_combined_details):
-    page = get_document(movie_combined_details['ates_parcasi'])
+    page = get_page(movie_combined_details['ates_parcasi'])
     data = parser.parse(page)['data']
     assert 'votes' not in data
 
 
 @mark.fragile
 def test_rank_top250_should_be_between_1_and_250(movie_combined_details):
-    page = get_document(movie_combined_details['matrix'])
+    page = get_page(movie_combined_details['matrix'])
     data = parser.parse(page)['data']
     assert 1 <= data['top 250 rank'] <= 250
 
 
 @mark.fragile
 def test_rank_bottom100_should_be_between_1_and_100(movie_combined_details):
-    page = get_document(movie_combined_details['manos'])
+    page = get_page(movie_combined_details['manos'])
     data = parser.parse(page)['data']
     assert 1 <= data['bottom 100 rank'] <= 100
 
 
 def test_rank_none_should_be_excluded(movie_combined_details):
-    page = get_document(movie_combined_details['ates_parcasi'])
+    page = get_page(movie_combined_details['ates_parcasi'])
     data = parser.parse(page)['data']
     assert 'top 250 rank' not in data
     assert 'bottom 100 rank' not in data
@@ -306,113 +306,113 @@ def test_rank_none_should_be_excluded(movie_combined_details):
 
 @mark.fragile
 def test_series_season_titles_should_be_a_list_of_season_titles(movie_combined_details):
-    page = get_document(movie_combined_details['dr_who'])
+    page = get_page(movie_combined_details['dr_who'])
     data = parser.parse(page)['data']
     assert data['seasons'] == [str(i) for i in range(1, 12)] + ['unknown']
 
 
 def test_series_season_titles_none_should_be_excluded(movie_combined_details):
-    page = get_document(movie_combined_details['dr_who_blink'])
+    page = get_page(movie_combined_details['dr_who_blink'])
     data = parser.parse(page)['data']
     assert 'seasons' not in data
 
 
 def test_series_number_of_seasons_numeric_should_be_ok(movie_combined_details):
-    page = get_document(movie_combined_details['house'])
+    page = get_page(movie_combined_details['house'])
     data = parser.parse(page)['data']
     assert data['number of seasons'] == 8
 
 
 @mark.fragile
 def test_series_number_of_seasons_should_exclude_non_numeric_season_titles(movie_combined_details):
-    page = get_document(movie_combined_details['dr_who'])
+    page = get_page(movie_combined_details['dr_who'])
     data = parser.parse(page)['data']
     assert data['number of seasons'] == 11
 
 
 def test_original_air_date_should_be_a_date(movie_combined_details):
-    page = get_document(movie_combined_details['dr_who_blink'])
+    page = get_page(movie_combined_details['dr_who_blink'])
     data = parser.parse(page)['data']
     assert data['original air date'] == '9 June 2007'
 
 
 def test_original_air_date_none_should_be_excluded(movie_combined_details):
-    page = get_document(movie_combined_details['dr_who'])
+    page = get_page(movie_combined_details['dr_who'])
     data = parser.parse(page)['data']
     assert 'original air date' not in data
 
 
 def test_season_and_episode_numbers_should_be_integers(movie_combined_details):
-    page = get_document(movie_combined_details['dr_who_blink'])
+    page = get_page(movie_combined_details['dr_who_blink'])
     data = parser.parse(page)['data']
     assert data['season'] == 3
     assert data['episode'] == 10
 
 
 def test_season_and_episode_numbers_none_should_be_excluded(movie_combined_details):
-    page = get_document(movie_combined_details['dr_who'])
+    page = get_page(movie_combined_details['dr_who'])
     data = parser.parse(page)['data']
     assert 'season' not in data
     assert 'episode' not in data
 
 
 def test_genres_single_should_be_a_list_of_genre_names(movie_combined_details):
-    page = get_document(movie_combined_details['if'])
+    page = get_page(movie_combined_details['if'])
     data = parser.parse(page)['data']
     assert data['genres'] == ['Drama']
 
 
 def test_genres_multiple_should_be_a_list_of_genre_names(movie_combined_details):
-    page = get_document(movie_combined_details['matrix'])
+    page = get_page(movie_combined_details['matrix'])
     data = parser.parse(page)['data']
     assert data['genres'] == ['Action', 'Sci-Fi']
 
 
 # TODO: find a movie with no genre
 # def test_genres_none_should_be_excluded(movie_combined_details):
-#     page = get_document(movie_combined_details, '???')
+#     page = get_page(movie_combined_details, '???')
 #     data = parser.parse(page)['data']
 #     assert 'genres' not in data
 
 
 def test_plot_outline_should_be_a_longer_text(movie_combined_details):
-    page = get_document(movie_combined_details['matrix'])
+    page = get_page(movie_combined_details['matrix'])
     data = parser.parse(page)['data']
     assert re.match('^A computer hacker .* against its controllers.$', data['plot outline'])
 
 
 def test_plot_outline_none_should_be_excluded(movie_combined_details):
-    page = get_document(movie_combined_details['ates_parcasi'])
+    page = get_page(movie_combined_details['ates_parcasi'])
     data = parser.parse(page)['data']
     assert 'plot outline' not in data
 
 
 def test_mpaa_should_be_a_rating(movie_combined_details):
-    page = get_document(movie_combined_details['matrix'])
+    page = get_page(movie_combined_details['matrix'])
     data = parser.parse(page)['data']
     assert data['mpaa'] == 'Rated R for sci-fi violence and brief language'
 
 
 def test_mpaa_none_should_be_excluded(movie_combined_details):
-    page = get_document(movie_combined_details['ates_parcasi'])
+    page = get_page(movie_combined_details['ates_parcasi'])
     data = parser.parse(page)['data']
     assert 'mpaa' not in data
 
 
 def test_runtimes_single_should_be_a_list_in_minutes(movie_combined_details):
-    page = get_document(movie_combined_details['matrix'])
+    page = get_page(movie_combined_details['matrix'])
     data = parser.parse(page)['data']
     assert data['runtimes'] == ['136']
 
 
 def test_runtimes_with_countries_should_include_context(movie_combined_details):
-    page = get_document(movie_combined_details['suspiria'])
+    page = get_page(movie_combined_details['suspiria'])
     data = parser.parse(page)['data']
     assert data['runtimes'] == ['98', 'Germany:88', 'USA:92', 'Argentina:95']
 
 
 def test_runtimes_multiple_with_notes_should_include_notes(movie_combined_details):
-    page = get_document(movie_combined_details['shining'])
+    page = get_page(movie_combined_details['shining'])
     data = parser.parse(page)['data']
     assert data['runtimes'] == [
         '144::(cut)',
@@ -423,63 +423,63 @@ def test_runtimes_multiple_with_notes_should_include_notes(movie_combined_detail
 
 
 def test_runtimes_none_should_be_excluded(movie_combined_details):
-    page = get_document(movie_combined_details['matrix_vg'])
+    page = get_page(movie_combined_details['matrix_vg'])
     data = parser.parse(page)['data']
     assert 'runtimes' not in data
 
 
 def test_countries_single_should_be_a_list_of_country_names(movie_combined_details):
-    page = get_document(movie_combined_details['matrix'])
+    page = get_page(movie_combined_details['matrix'])
     data = parser.parse(page)['data']
     assert data['countries'] == ['USA']
 
 
 def test_countries_multiple_should_be_a_list_of_country_names(movie_combined_details):
-    page = get_document(movie_combined_details['shining'])
+    page = get_page(movie_combined_details['shining'])
     data = parser.parse(page)['data']
     assert data['countries'] == ['UK', 'USA']
 
 
 # TODO: find a movie with no country
 # def test_countries_none_should_be_excluded(movie_combined_details):
-#     page = get_document(movie_combined_details, '???')
+#     page = get_page(movie_combined_details, '???')
 #     data = parser.parse(page)['data']
 #     assert 'countries' not in data
 
 
 def test_country_codes_single_should_be_a_list_of_country_codes(movie_combined_details):
-    page = get_document(movie_combined_details['matrix'])
+    page = get_page(movie_combined_details['matrix'])
     data = parser.parse(page)['data']
     assert data['country codes'] == ['us']
 
 
 def test_country_codes_multiple_should_be_a_list_of_country_codes(movie_combined_details):
-    page = get_document(movie_combined_details['shining'])
+    page = get_page(movie_combined_details['shining'])
     data = parser.parse(page)['data']
     assert data['country codes'] == ['gb', 'us']
 
 
 # TODO: find a movie with no country
 # def test_country_codes_none_should_be_excluded(movie_combined_details):
-#     page = get_document(movie_combined_details, '???')
+#     page = get_page(movie_combined_details, '???')
 #     data = parser.parse(page)['data']
 #     assert 'country codes' not in data
 
 
 def test_languages_single_should_be_a_list_of_language_names(movie_combined_details):
-    page = get_document(movie_combined_details['matrix'])
+    page = get_page(movie_combined_details['matrix'])
     data = parser.parse(page)['data']
     assert data['languages'] == ['English']
 
 
 def test_languages_multiple_should_be_a_list_of_language_names(movie_combined_details):
-    page = get_document(movie_combined_details['ace_in_the_hole'])
+    page = get_page(movie_combined_details['ace_in_the_hole'])
     data = parser.parse(page)['data']
     assert data['languages'] == ['English', 'Spanish', 'Latin']
 
 
 def test_languages_single_none_as_a_language_name_should_be_valid(movie_combined_details):
-    page = get_document(movie_combined_details['matrix_short'])
+    page = get_page(movie_combined_details['matrix_short'])
     data = parser.parse(page)['data']
     assert data['languages'] == ['None']
 
@@ -492,19 +492,19 @@ def test_languages_single_none_as_a_language_name_should_be_valid(movie_combined
 
 
 def test_language_codes_single_should_be_a_list_of_language_names(movie_combined_details):
-    page = get_document(movie_combined_details['matrix'])
+    page = get_page(movie_combined_details['matrix'])
     data = parser.parse(page)['data']
     assert data['language codes'] == ['en']
 
 
 def test_language_codes_multiple_should_be_a_list_of_language_names(movie_combined_details):
-    page = get_document(movie_combined_details['ace_in_the_hole'])
+    page = get_page(movie_combined_details['ace_in_the_hole'])
     data = parser.parse(page)['data']
     assert data['language codes'] == ['en', 'es', 'la']
 
 
 def test_language_codes_single_none_as_a_language_name_should_be_valid(movie_combined_details):
-    page = get_document(movie_combined_details['matrix_short'])
+    page = get_page(movie_combined_details['matrix_short'])
     data = parser.parse(page)['data']
     assert data['language codes'] == ['zxx']
 
@@ -517,30 +517,30 @@ def test_language_codes_single_none_as_a_language_name_should_be_valid(movie_com
 
 
 def test_colors_single_should_be_a_list_of_color_types(movie_combined_details):
-    page = get_document(movie_combined_details['matrix'])
+    page = get_page(movie_combined_details['matrix'])
     data = parser.parse(page)['data']
     assert data['color info'] == ['Color']
 
 
 def test_colors_multiple_should_be_a_list_of_color_types(movie_combined_details):
-    page = get_document(movie_combined_details['pleasantville'])
+    page = get_page(movie_combined_details['pleasantville'])
     data = parser.parse(page)['data']
     assert data['color info'] == ['Black and White', 'Color']
 
 
 def test_colors_with_notes_single_should_include_notes(movie_combined_details):
-    page = get_document(movie_combined_details['manos'])
+    page = get_page(movie_combined_details['manos'])
     data = parser.parse(page)['data']
     assert data['color info'] == ['Color::(Eastmancolor)']
 
 
 def test_colors_with_notes_multiple_should_include_notes(movie_combined_details):
-    page = get_document(movie_combined_details['if'])
+    page = get_page(movie_combined_details['if'])
     data = parser.parse(page)['data']
     assert data['color info'] == ['Black and White', 'Color::(Eastmancolor) (uncredited)']
 
 
 def test_colors_none_should_be_excluded(movie_combined_details):
-    page = get_document(movie_combined_details['matrix_tv'])
+    page = get_page(movie_combined_details['matrix_tv'])
     data = parser.parse(page)['data']
     assert 'color info' not in data

--- a/tests/test_http_person_main.py
+++ b/tests/test_http_person_main.py
@@ -1,6 +1,5 @@
 from pytest import fixture, mark
 
-import re
 from urllib.request import urlopen
 
 from imdb.parser.http.personParser import DOMHTMLMaindetailsParser

--- a/tests/test_http_person_main.py
+++ b/tests/test_http_person_main.py
@@ -1,0 +1,55 @@
+from pytest import fixture, mark
+
+import re
+from urllib.request import urlopen
+
+from imdb.parser.http.personParser import DOMHTMLMaindetailsParser
+
+
+@fixture(scope='module')
+def person_main_details(people):
+    """A function to retrieve the main details page of a test person."""
+    def retrieve(person_key):
+        url = people[person_key]
+        return urlopen(url).read().decode('utf-8')
+    return retrieve
+
+
+parser = DOMHTMLMaindetailsParser()
+
+
+def test_headshot_should_be_a_link(person_main_details):
+    page = person_main_details('keanu_reeves')
+    data = parser.parse(page)['data']
+    assert data['headshot'].endswith('.jpg')
+
+
+@mark.fragile
+def test_headshot_none_should_be_excluded(person_main_details):
+    page = person_main_details('deni_gordon')
+    data = parser.parse(page)['data']
+    assert 'headshot' not in data
+
+
+def test_name_should_be_canonical(person_main_details):
+    page = person_main_details('keanu_reeves')
+    data = parser.parse(page)['data']
+    assert data['name'] == 'Reeves, Keanu'
+
+
+def test_name_should_not_have_year(person_main_details):
+    page = person_main_details('fred_astaire')
+    data = parser.parse(page)['data']
+    assert data['name'] == 'Astaire, Fred'
+
+
+def test_imdb_index_should_be_a_roman_number(person_main_details):
+    page = person_main_details('julia_roberts')
+    data = parser.parse(page)['data']
+    assert data['imdbIndex'] == 'I'
+
+
+def test_imdb_index_none_should_be_excluded(person_main_details):
+    page = person_main_details('keanu_reeves')
+    data = parser.parse(page)['data']
+    assert 'imdbIndex' not in data


### PR DESCRIPTION
This fixes color info with notes parsing in the movie combined parser. It also fixes the test data for series seasons and adds some person tests. Now all initial tests for the movie combined parser pass for Python 3.3, 3.4, 3.5, 3.6, and pypy3, both with and without lxml.