### PR TITLE
Use IMDbPY's URL opener in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,10 @@
 from pytest import fixture
-from unittest import mock
 
 import logging
 import os
-import urllib.request
 from hashlib import md5
-from io import BytesIO
-from urllib.request import urlopen as orig_urlopen
 
+from imdb.parser.http import IMDbURLopener
 
 logging.raiseExceptions = False
 
@@ -17,20 +14,18 @@ if not os.path.exists(cache_dir):
     os.makedirs(cache_dir)
 
 
-def mock_urlopen(url):
-    key = md5(url.encode('utf-8')).hexdigest()
-    cache_file = os.path.join(cache_dir, key)
-    if os.path.exists(cache_file):
-        with open(cache_file, 'rb') as f:
-            content = f.read()
-    else:
-        content = orig_urlopen(url).read()
-        with open(cache_file, 'wb') as f:
-            f.write(content)
-    return BytesIO(content)
-
-
-urllib.request.urlopen = mock.Mock(wraps=mock_urlopen)
+class CachedURLOpener(IMDbURLopener):
+    def retrieve_unicode(self, url, size=-1):
+        key = md5(url.encode('utf-8')).hexdigest()
+        cache_file = os.path.join(cache_dir, key)
+        if os.path.exists(cache_file):
+            with open(cache_file, 'r') as f:
+                content = f.read()
+        else:
+            content = super().retrieve_unicode(url, size=size)
+            with open(cache_file, 'w') as f:
+                f.write(content)
+        return content
 
 
 BASE_URL = 'http://akas.imdb.com'
@@ -68,6 +63,11 @@ PEOPLE = {
     '0000206': 'keanu reeves',              # no IMDb index
     '0000210': 'julia roberts'              # IMDb index
 }
+
+
+@fixture(scope='session')
+def url_opener():
+    return CachedURLOpener()
 
 
 @fixture(scope='session')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from hashlib import md5
 
 from imdb.parser.http import IMDbURLopener
 
+
 logging.raiseExceptions = False
 
 

--- a/tests/test_http_chart_bottom.py
+++ b/tests/test_http_chart_bottom.py
@@ -1,16 +1,14 @@
 from pytest import fixture
 
-from urllib.request import urlopen
-
 from imdb.parser.http.topBottomParser import DOMHTMLBottom100Parser
 
 
 @fixture(scope='module')
-def chart_bottom(base_url):
+def chart_bottom(url_opener, base_url):
     """A function to retrieve the bottom movies page."""
     def retrieve():
         url = base_url + '/chart/bottom'
-        return urlopen(url).read().decode('utf-8')
+        return url_opener.retrieve_unicode(url)
     return retrieve
 
 

--- a/tests/test_http_chart_top.py
+++ b/tests/test_http_chart_top.py
@@ -1,16 +1,14 @@
 from pytest import fixture
 
-from urllib.request import urlopen
-
 from imdb.parser.http.topBottomParser import DOMHTMLTop250Parser
 
 
 @fixture(scope='module')
-def chart_top(base_url):
+def chart_top(url_opener, base_url):
     """A function to retrieve the top movies page."""
     def retrieve():
         url = base_url + '/chart/top'
-        return urlopen(url).read().decode('utf-8')
+        return url_opener.retrieve_unicode(url)
     return retrieve
 
 

--- a/tests/test_http_movie_combined.py
+++ b/tests/test_http_movie_combined.py
@@ -1,17 +1,16 @@
 from pytest import fixture, mark
 
 import re
-from urllib.request import urlopen
 
 from imdb.parser.http.movieParser import DOMHTMLMovieParser
 
 
 @fixture(scope='module')
-def movie_combined_details(movies):
+def movie_combined_details(url_opener, movies):
     """A function to retrieve the combined details page of a test movie."""
     def retrieve(movie_key):
         url = movies[movie_key] + '/combined'
-        return urlopen(url).read().decode('utf-8')
+        return url_opener.retrieve_unicode(url)
     return retrieve
 
 

--- a/tests/test_http_movie_combined.py
+++ b/tests/test_http_movie_combined.py
@@ -17,10 +17,10 @@ def movie_combined_details(url_opener, movies):
 parser = DOMHTMLMovieParser()
 
 
-def test_cover_url_should_be_a_link(movie_combined_details):
+def test_cover_url_should_be_an_image_link(movie_combined_details):
     page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
-    assert data['cover url'].endswith('.jpg')
+    assert re.match(r'^https?://.*\.jpg$', data['cover url'])
 
 
 def test_cover_url_none_should_be_excluded(movie_combined_details):

--- a/tests/test_http_movie_keywords.py
+++ b/tests/test_http_movie_keywords.py
@@ -1,16 +1,14 @@
 from pytest import fixture
 
-from urllib.request import urlopen
-
 from imdb.parser.http.movieParser import DOMHTMLKeywordsParser
 
 
 @fixture(scope='module')
-def movie_keywords(movies):
+def movie_keywords(url_opener, movies):
     """A function to retrieve the keywords page of a test movie."""
     def retrieve(movie_key):
         url = movies[movie_key] + '/keywords'
-        return urlopen(url).read().decode('utf-8')
+        return url_opener.retrieve_unicode(url)
     return retrieve
 
 

--- a/tests/test_http_movie_plot.py
+++ b/tests/test_http_movie_plot.py
@@ -1,17 +1,16 @@
 from pytest import fixture
 
 import re
-from urllib.request import urlopen
 
 from imdb.parser.http.movieParser import DOMHTMLPlotParser
 
 
 @fixture(scope='module')
-def movie_plot_summaries(movies):
+def movie_plot_summaries(url_opener, movies):
     """A function to retrieve the plot summary page of a test movie."""
     def retrieve(movie_key):
         url = movies[movie_key] + '/plotsummary'
-        return urlopen(url).read().decode('utf-8')
+        return url_opener.retrieve_unicode(url)
     return retrieve
 
 

--- a/tests/test_http_movie_taglines.py
+++ b/tests/test_http_movie_taglines.py
@@ -1,16 +1,14 @@
 from pytest import fixture
 
-from urllib.request import urlopen
-
 from imdb.parser.http.movieParser import DOMHTMLTaglinesParser
 
 
 @fixture(scope='module')
-def movie_taglines(movies):
+def movie_taglines(url_opener, movies):
     """A function to retrieve the taglines page of a test movie."""
     def retrieve(movie_key):
         url = movies[movie_key] + '/taglines'
-        return urlopen(url).read().decode('utf-8')
+        return url_opener.retrieve_unicode(url)
     return retrieve
 
 

--- a/tests/test_http_movie_votes.py
+++ b/tests/test_http_movie_votes.py
@@ -15,34 +15,39 @@ def movie_ratings(url_opener, movies):
 parser = DOMHTMLRatingsParser()
 
 
-def test_movie_ratings_nr_votes_must_be_10(movie_ratings):
+def test_movie_ratings_nr_votes_should_be_10(movie_ratings):
     page = movie_ratings('matrix')
     data = parser.parse(page)['data']
     assert len(data['number of votes']) == 10
 
-def test_movie_ratings_nr_votes_must_integer(movie_ratings):
+
+def test_movie_ratings_nr_votes_should_be_integer(movie_ratings):
     page = movie_ratings('matrix')
     data = parser.parse(page)['data']
-    assert isinstance(data['number of votes'][10],  int)
+    assert isinstance(data['number of votes'][10], int)
 
-def test_movie_ratings_median_must_integer(movie_ratings):
+
+def test_movie_ratings_median_should_integer(movie_ratings):
     page = movie_ratings('matrix')
     data = parser.parse(page)['data']
-    assert isinstance(data['median'],  int)
+    assert isinstance(data['median'], int)
 
-def test_movie_ratings_mean_must_numeric(movie_ratings):
+
+def test_movie_ratings_mean_should_be_numeric(movie_ratings):
     page = movie_ratings('matrix')
     data = parser.parse(page)['data']
-    assert isinstance(data['arithmetic mean'],  float)
+    assert isinstance(data['arithmetic mean'], float)
 
-def test_movie_ratings_demographics_must_19(movie_ratings):
+
+def test_movie_ratings_demographics_should_be_19(movie_ratings):
     page = movie_ratings('matrix')
     data = parser.parse(page)['data']
     assert len(data['demographics']) == 19
 
-def test_movie_ratings_demographics_must_numeric(movie_ratings):
+
+def test_movie_ratings_demographics_should_be_numeric(movie_ratings):
     page = movie_ratings('matrix')
     data = parser.parse(page)['data']
     top1000 = data['demographics']['top 1000 voters']
-    assert isinstance(top1000['votes'],  int)
-    assert isinstance(top1000['rating'],  float)
+    assert isinstance(top1000['votes'], int)
+    assert isinstance(top1000['rating'], float)

--- a/tests/test_http_movie_votes.py
+++ b/tests/test_http_movie_votes.py
@@ -1,16 +1,14 @@
 from pytest import fixture
 
-from urllib.request import urlopen
-
 from imdb.parser.http.movieParser import DOMHTMLRatingsParser
 
 
 @fixture(scope='module')
-def movie_ratings(movies):
+def movie_ratings(url_opener, movies):
     """A function to retrieve the ratings page of a test movie."""
     def retrieve(movie_key):
         url = movies[movie_key] + '/ratings'
-        return urlopen(url).read().decode('utf-8')
+        return url_opener.retrieve_unicode(url)
     return retrieve
 
 

--- a/tests/test_http_person_main.py
+++ b/tests/test_http_person_main.py
@@ -1,16 +1,14 @@
 from pytest import fixture
 
-from urllib.request import urlopen
-
 from imdb.parser.http.personParser import DOMHTMLMaindetailsParser
 
 
 @fixture(scope='module')
-def person_main_details(people):
+def person_main_details(url_opener, people):
     """A function to retrieve the main details page of a test person."""
     def retrieve(person_key):
         url = people[person_key]
-        return urlopen(url).read().decode('utf-8')
+        return url_opener.retrieve_unicode(url)
     return retrieve
 
 

--- a/tests/test_http_search_character.py
+++ b/tests/test_http_search_character.py
@@ -1,16 +1,14 @@
 from pytest import fixture, mark
 
-from urllib.request import urlopen
-
 from imdb.parser.http.searchCharacterParser import DOMHTMLSearchCharacterParser
 
 
 @fixture(scope='module')
-def search_character(search):
+def search_character(url_opener, search):
     """A function to retrieve the search result for a character."""
     def retrieve(term):
         url = search + '?s=ch&q=' + term.replace(' ', '+')
-        return urlopen(url).read().decode('utf-8')
+        return url_opener.retrieve_unicode(url)
     return retrieve
 
 

--- a/tests/test_http_search_company.py
+++ b/tests/test_http_search_company.py
@@ -1,16 +1,14 @@
 from pytest import fixture, mark
 
-from urllib.request import urlopen
-
 from imdb.parser.http.searchCompanyParser import DOMHTMLSearchCompanyParser
 
 
 @fixture(scope='module')
-def search_company(search):
+def search_company(url_opener, search):
     """A function to retrieve the search result for a company."""
     def retrieve(term):
         url = search + '?s=co&q=' + term.replace(' ', '+')
-        return urlopen(url).read().decode('utf-8')
+        return url_opener.retrieve_unicode(url)
     return retrieve
 
 

--- a/tests/test_http_search_movie.py
+++ b/tests/test_http_search_movie.py
@@ -27,7 +27,7 @@ def test_found_one_result_should_be_list_with_one_movie(search_movie):
 def test_found_many_result_should_contain_correct_number_of_movies(search_movie):
     page = search_movie('ace in the hole')
     data = parser.parse(page)['data']
-    assert len(data) == 186
+    assert len(data) < 200
 
 
 def test_found_too_many_result_should_contain_200_movies(search_movie):

--- a/tests/test_http_search_movie.py
+++ b/tests/test_http_search_movie.py
@@ -1,16 +1,14 @@
 from pytest import fixture, mark
 
-from urllib.request import urlopen
-
 from imdb.parser.http.searchMovieParser import DOMHTMLSearchMovieParser
 
 
 @fixture(scope='module')
-def search_movie(search):
+def search_movie(url_opener, search):
     """A function to retrieve the search result for a title."""
     def retrieve(term):
         url = search + '?s=tt&q=' + term.replace(' ', '+')
-        return urlopen(url).read().decode('utf-8')
+        return url_opener.retrieve_unicode(url)
     return retrieve
 
 

--- a/tests/test_http_search_movie.py
+++ b/tests/test_http_search_movie.py
@@ -27,7 +27,7 @@ def test_found_one_result_should_be_list_with_one_movie(search_movie):
 def test_found_many_result_should_contain_correct_number_of_movies(search_movie):
     page = search_movie('ace in the hole')
     data = parser.parse(page)['data']
-    assert len(data) < 200
+    assert len(data) == 187
 
 
 def test_found_too_many_result_should_contain_200_movies(search_movie):

--- a/tests/test_http_search_person.py
+++ b/tests/test_http_search_person.py
@@ -1,16 +1,14 @@
 from pytest import fixture, mark
 
-from urllib.request import urlopen
-
 from imdb.parser.http.searchPersonParser import DOMHTMLSearchPersonParser
 
 
 @fixture(scope='module')
-def search_person(search):
+def search_person(url_opener, search):
     """A function to retrieve the search result for a person."""
     def retrieve(term):
         url = search + '?s=nm&q=' + term.replace(' ', '+')
-        return urlopen(url).read().decode('utf-8')
+        return url_opener.retrieve_unicode(url)
     return retrieve
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py{36,35,34,33}, pypy3, style
 [testenv]
 deps =
     pytest
-    mock
+    lxml
 commands =
     {posargs:py.test}
 


### PR DESCRIPTION
This PR makes the tests use IMDbPY's URL opener instead of urllib.urlopen. This makes sure that the URL opener is tested and also makes it possible to test the parts which include cookie handling.