### PR TITLE
Change XPath query for title

### DIFF
--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -174,7 +174,7 @@ class DOMHTMLMovieParser(DOMParserBase):
     extractors = [
         Extractor(
             label='title',
-            path="//h1",
+            path="//h1[@itemprop='name']",
             attrs=Attribute(
                 key='title',
                 path=".//text()",


### PR DESCRIPTION
Related to https://github.com/alberanid/imdbpy/issues/103, changes XPath query for title so it now points to a proper `<h1>` node.