### PR TITLE
[legacy] Change XPath query for title

### DIFF
--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -165,7 +165,7 @@ class DOMHTMLMovieParser(DOMParserBase):
     _containsObjects = True
 
     extractors = [Extractor(label='title',
-                            path="//h1",
+                            path="//h1[@itemprop='name']",
                             attrs=Attribute(key='title',
                                         path=".//text()",
                                         postprocess=analyze_title)),


### PR DESCRIPTION
Same as https://github.com/alberanid/imdbpy/pull/104 but for legacy branch. Related to #103, changes XPath query for title so it now points to a proper `<h1>` node.