### PR TITLE
Fix movie parsing with failing tests

### DIFF
--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -240,6 +240,17 @@ class DOMHTMLMovieParser(DOMParserBase):
         ),
 
         Extractor(
+            label='sound mix',
+            path=".//td[starts-with(text(), 'Sound Mix')]/..//li/a",
+            attrs=Attribute(
+                key='sound mix',
+                path="./text()",
+                multi=True,
+                postprocess=lambda x: x.replace(' (', '::(')
+            )
+        ),
+
+        Extractor(
             label='h5sections',
             path="//section[contains(@class, 'listo')]",
             attrs=[
@@ -274,12 +285,6 @@ class DOMHTMLMovieParser(DOMParserBase):
                     path=".//td[starts-with(text(), 'Color')]/..//li/a/text()",
                     multi=True,
                     postprocess=lambda x: x.replace(' (', '::(')
-                ),
-                Attribute(
-                    key='sound mix',
-                    path=".//td[starts-with(text(), 'Sound Mix')]/.."
-                         "/div[@class='info-content']//text()",
-                    postprocess=makeSplitter()
                 ),
                 # Collects akas not encosed in <i> tags.
                 Attribute(

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -245,7 +245,7 @@ class DOMHTMLMovieParser(DOMParserBase):
             attrs=[
                 Attribute(
                     key="plot summary",
-                    path=".//td[starts-with(text(), 'Plot:')]/../div/text()",
+                    path=".//td[starts-with(text(), 'Plot')]/..//p/text()",
                     postprocess=lambda x: x.strip().rstrip('|').rstrip()
                 ),
                 Attribute(

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -271,9 +271,9 @@ class DOMHTMLMovieParser(DOMParserBase):
                 ),
                 Attribute(
                     key='color info',
-                    path=".//td[starts-with(text(), 'Color')]/.."
-                         "/div[@class='info-content']//text()",
-                    postprocess=makeSplitter('|')
+                    path=".//td[starts-with(text(), 'Color')]/..//li/a/text()",
+                    multi=True,
+                    postprocess=lambda x: x.replace(' (', '::(')
                 ),
                 Attribute(
                     key='sound mix',

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -250,6 +250,27 @@ class DOMHTMLMovieParser(DOMParserBase):
         ),
 
         Extractor(
+            label='countries',
+            path="//td[starts-with(text(), 'Countr')]/..//li/a",
+            attrs=Attribute(
+                key='countries',
+                path="./text()",
+                multi=True
+            )
+        ),
+
+        Extractor(
+            label='country codes',
+            path="//td[starts-with(text(), 'Countr')]/..//li/a",
+            attrs=Attribute(
+                key='country codes',
+                path="./@href",
+                multi=True,
+                postprocess=lambda x: x.split('/')[2].strip().lower()
+            )
+        ),
+
+        Extractor(
             label='color info',
             path="//td[starts-with(text(), 'Color')]/..//li/a",
             attrs=Attribute(
@@ -290,12 +311,6 @@ class DOMHTMLMovieParser(DOMParserBase):
                 #     path=".//td/a[starts-with(text(), 'MPAA')]/../../div/text()",
                 #     postprocess=lambda x: x.strip()
                 # ),
-                Attribute(
-                    key="countries",
-                    path=".//td[starts-with(text(), 'Countr')]/.."
-                         "/div[@class='info-content']//text()",
-                    postprocess=makeSplitter('|')
-                ),
                 Attribute(
                     key="language",
                     path=".//td[starts-with(text(), 'Language')]/..//text()",
@@ -345,17 +360,6 @@ class DOMHTMLMovieParser(DOMParserBase):
                  "//a[starts-with(@href, '/language/')]",
             attrs=Attribute(
                 key='language codes',
-                multi=True,
-                path="./@href",
-                postprocess=lambda x: x.split('/')[2].strip()
-            )
-        ),
-
-        Extractor(
-            label='country codes',
-            path="//td[starts-with(text(), 'Country')]/..//a[starts-with(@href, '/country/')]",
-            attrs=Attribute(
-                key='country codes',
                 multi=True,
                 path="./@href",
                 postprocess=lambda x: x.split('/')[2].strip()

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -250,6 +250,17 @@ class DOMHTMLMovieParser(DOMParserBase):
         ),
 
         Extractor(
+            label='runtimes',
+            path="//td[starts-with(text(), 'Runtime')]/..//li",
+            attrs=Attribute(
+                key='runtimes',
+                path="./text()",
+                multi=True,
+                postprocess=lambda x: x.strip().replace(' min', '')
+            )
+        ),
+
+        Extractor(
             label='countries',
             path="//td[starts-with(text(), 'Countr')]/..//li/a",
             attrs=Attribute(
@@ -339,11 +350,6 @@ class DOMHTMLMovieParser(DOMParserBase):
                     postprocess=makeSplitter(
                         sep='::', origNotesSep='" - ', newNotesSep='::', strip='"'
                     )
-                ),
-                Attribute(
-                    key='runtimes',
-                    path=".//td[starts-with(text(), 'Runtime')]/..//ul//text()",
-                    postprocess=makeSplitter()
                 ),
                 Attribute(
                     key='certificates',

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -221,6 +221,15 @@ class DOMHTMLMovieParser(DOMParserBase):
         ),
 
         Extractor(
+            label='myrating',
+            path="//span[@id='voteuser']",
+            attrs=Attribute(
+                key='myrating',
+                path=".//text()"
+            )
+        ),
+
+        Extractor(
             label='genres',
             path="//td[starts-with(text(), 'Genre')]/..//li/a",
             attrs=Attribute(
@@ -231,17 +240,8 @@ class DOMHTMLMovieParser(DOMParserBase):
         ),
 
         Extractor(
-            label='myrating',
-            path="//span[@id='voteuser']",
-            attrs=Attribute(
-                key='myrating',
-                path=".//text()"
-            )
-        ),
-
-        Extractor(
             label='color info',
-            path=".//td[starts-with(text(), 'Color')]/..//li/a",
+            path="//td[starts-with(text(), 'Color')]/..//li/a",
             attrs=Attribute(
                 key='color info',
                 path="./text()",
@@ -252,7 +252,7 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='sound mix',
-            path=".//td[starts-with(text(), 'Sound Mix')]/..//li/a",
+            path="//td[starts-with(text(), 'Sound Mix')]/..//li/a",
             attrs=Attribute(
                 key='sound mix',
                 path="./text()",

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -271,6 +271,27 @@ class DOMHTMLMovieParser(DOMParserBase):
         ),
 
         Extractor(
+            label='language',
+            path="//td[starts-with(text(), 'Language')]/..//li/a",
+            attrs=Attribute(
+                key='language',
+                path="./text()",
+                multi=True
+            )
+        ),
+
+        Extractor(
+            label='language codes',
+            path="//td[starts-with(text(), 'Language')]/..//li/a",
+            attrs=Attribute(
+                key='language codes',
+                path="./@href",
+                multi=True,
+                postprocess=lambda x: x.split('/')[2].strip()
+            )
+        ),
+
+        Extractor(
             label='color info',
             path="//td[starts-with(text(), 'Color')]/..//li/a",
             attrs=Attribute(
@@ -311,11 +332,6 @@ class DOMHTMLMovieParser(DOMParserBase):
                 #     path=".//td/a[starts-with(text(), 'MPAA')]/../../div/text()",
                 #     postprocess=lambda x: x.strip()
                 # ),
-                Attribute(
-                    key="language",
-                    path=".//td[starts-with(text(), 'Language')]/..//text()",
-                    postprocess=makeSplitter('Language:')
-                ),
                 # Collects akas not encosed in <i> tags.
                 Attribute(
                     key='other akas',
@@ -352,18 +368,6 @@ class DOMHTMLMovieParser(DOMParserBase):
                     path=".//td[starts-with(text(), 'TV Series')]/..//a/text()"
                 )
             ]
-        ),
-
-        Extractor(
-            label='language codes',
-            path="//td[starts-with(text(), 'Language')]/.."
-                 "//a[starts-with(@href, '/language/')]",
-            attrs=Attribute(
-                key='language codes',
-                multi=True,
-                path="./@href",
-                postprocess=lambda x: x.split('/')[2].strip()
-            )
         ),
 
         Extractor(

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -231,10 +231,10 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='plot summary',
-            path=".//td[starts-with(text(), 'Plot')]/..",
+            path=".//td[starts-with(text(), 'Plot')]/..//p",
             attrs=Attribute(
                 key='plot summary',
-                path='./p//text()',
+                path='./text()',
                 postprocess=lambda x: x.strip().rstrip('|').rstrip()
             )
         ),
@@ -285,11 +285,6 @@ class DOMHTMLMovieParser(DOMParserBase):
             label='h5sections',
             path="//section[contains(@class, 'listo')]",
             attrs=[
-                Attribute(
-                    key="plot summary",
-                    path=".//td[starts-with(text(), 'Plot')]/..//p/text()",
-                    postprocess=lambda x: x.strip().rstrip('|').rstrip()
-                ),
                 # Attribute(
                 #     key="mpaa",
                 #     path=".//td/a[starts-with(text(), 'MPAA')]/../../div/text()",

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -250,7 +250,7 @@ class DOMHTMLMovieParser(DOMParserBase):
                 ),
                 Attribute(
                     key="aspect ratio",
-                    path=".//td[starts-with(text(), 'Aspect')]/../div/text()",
+                    path=".//td[starts-with(text(), 'Aspect')]/..//li/text()",
                     postprocess=lambda x: x.strip()
                 ),
                 Attribute(

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -253,11 +253,11 @@ class DOMHTMLMovieParser(DOMParserBase):
                     path=".//td[starts-with(text(), 'Aspect')]/..//li/text()",
                     postprocess=lambda x: x.strip()
                 ),
-                Attribute(
-                    key="mpaa",
-                    path=".//td/a[starts-with(text(), 'MPAA')]/../../div/text()",
-                    postprocess=lambda x: x.strip()
-                ),
+                # Attribute(
+                #     key="mpaa",
+                #     path=".//td/a[starts-with(text(), 'MPAA')]/../../div/text()",
+                #     postprocess=lambda x: x.strip()
+                # ),
                 Attribute(
                     key="countries",
                     path=".//td[starts-with(text(), 'Countr')]/.."

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -222,7 +222,7 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='genres',
-            path="//div[@class='info']//a[starts-with(@href, '/Sections/Genres')]",
+            path="//td[starts-with(text(), 'Genre')]/..//li/a",
             attrs=Attribute(
                 key="genres",
                 multi=True,

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -251,6 +251,16 @@ class DOMHTMLMovieParser(DOMParserBase):
         ),
 
         Extractor(
+            label='aspect ratio',
+            path="//td[starts-with(text(), 'Aspect')]/..",
+            attrs=Attribute(
+                key='aspect ratio',
+                path=".//li/text()",
+                postprocess=lambda x: x.strip()
+            )
+        ),
+
+        Extractor(
             label='sound mix',
             path="//td[starts-with(text(), 'Sound Mix')]/..//li/a",
             attrs=Attribute(
@@ -269,11 +279,6 @@ class DOMHTMLMovieParser(DOMParserBase):
                     key="plot summary",
                     path=".//td[starts-with(text(), 'Plot')]/..//p/text()",
                     postprocess=lambda x: x.strip().rstrip('|').rstrip()
-                ),
-                Attribute(
-                    key="aspect ratio",
-                    path=".//td[starts-with(text(), 'Aspect')]/..//li/text()",
-                    postprocess=lambda x: x.strip()
                 ),
                 # Attribute(
                 #     key="mpaa",

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -240,6 +240,17 @@ class DOMHTMLMovieParser(DOMParserBase):
         ),
 
         Extractor(
+            label='color info',
+            path=".//td[starts-with(text(), 'Color')]/..//li/a",
+            attrs=Attribute(
+                key='color info',
+                path="./text()",
+                multi=True,
+                postprocess=lambda x: x.replace(' (', '::(')
+            )
+        ),
+
+        Extractor(
             label='sound mix',
             path=".//td[starts-with(text(), 'Sound Mix')]/..//li/a",
             attrs=Attribute(
@@ -279,12 +290,6 @@ class DOMHTMLMovieParser(DOMParserBase):
                     key="language",
                     path=".//td[starts-with(text(), 'Language')]/..//text()",
                     postprocess=makeSplitter('Language:')
-                ),
-                Attribute(
-                    key='color info',
-                    path=".//td[starts-with(text(), 'Color')]/..//li/a/text()",
-                    multi=True,
-                    postprocess=lambda x: x.replace(' (', '::(')
                 ),
                 # Collects akas not encosed in <i> tags.
                 Attribute(

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -338,11 +338,6 @@ class DOMHTMLMovieParser(DOMParserBase):
             label='h5sections',
             path="//section[contains(@class, 'listo')]",
             attrs=[
-                # Attribute(
-                #     key="mpaa",
-                #     path=".//td/a[starts-with(text(), 'MPAA')]/../../div/text()",
-                #     postprocess=lambda x: x.strip()
-                # ),
                 # Collects akas not encosed in <i> tags.
                 Attribute(
                     key='other akas',

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -230,6 +230,16 @@ class DOMHTMLMovieParser(DOMParserBase):
         ),
 
         Extractor(
+            label='plot summary',
+            path=".//td[starts-with(text(), 'Plot')]/..",
+            attrs=Attribute(
+                key='plot summary',
+                path='./p//text()',
+                postprocess=lambda x: x.strip().rstrip('|').rstrip()
+            )
+        ),
+
+        Extractor(
             label='genres',
             path="//td[starts-with(text(), 'Genre')]/..//li/a",
             attrs=Attribute(

--- a/tests/test_http_movie_combined.py
+++ b/tests/test_http_movie_combined.py
@@ -402,12 +402,14 @@ def test_runtimes_single_should_be_a_list_in_minutes(movie_combined_details):
     assert data['runtimes'] == ['136']
 
 
+@mark.skip(reason='only a single runtime is included now')
 def test_runtimes_with_countries_should_include_context(movie_combined_details):
     page = movie_combined_details('suspiria')
     data = parser.parse(page)['data']
     assert data['runtimes'] == ['98', 'Germany:88', 'USA:92', 'Argentina:95']
 
 
+@mark.skip(reason='only a single runtime is included now')
 def test_runtimes_multiple_with_notes_should_include_notes(movie_combined_details):
     page = movie_combined_details('shining')
     data = parser.parse(page)['data']

--- a/tests/test_http_movie_combined.py
+++ b/tests/test_http_movie_combined.py
@@ -428,13 +428,13 @@ def test_runtimes_none_should_be_excluded(movie_combined_details):
 def test_countries_single_should_be_a_list_of_country_names(movie_combined_details):
     page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
-    assert data['countries'] == ['USA']
+    assert data['countries'] == ['United States']
 
 
 def test_countries_multiple_should_be_a_list_of_country_names(movie_combined_details):
     page = movie_combined_details('shining')
     data = parser.parse(page)['data']
-    assert data['countries'] == ['UK', 'USA']
+    assert data['countries'] == ['United Kingdom', 'United States']
 
 
 # TODO: find a movie with no country

--- a/tests/test_http_movie_combined.py
+++ b/tests/test_http_movie_combined.py
@@ -382,12 +382,14 @@ def test_plot_outline_none_should_be_excluded(movie_combined_details):
     assert 'plot outline' not in data
 
 
+@mark.skip(reason="mpaa rating is not included anymore")
 def test_mpaa_should_be_a_rating(movie_combined_details):
     page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
     assert data['mpaa'] == 'Rated R for sci-fi violence and brief language'
 
 
+@mark.skip(reason="mpaa rating is not included anymore")
 def test_mpaa_none_should_be_excluded(movie_combined_details):
     page = movie_combined_details('ates parcasi')
     data = parser.parse(page)['data']

--- a/tests/test_http_movie_combined.py
+++ b/tests/test_http_movie_combined.py
@@ -373,7 +373,7 @@ def test_genres_multiple_should_be_a_list_of_genre_names(movie_combined_details)
 def test_plot_outline_should_be_a_longer_text(movie_combined_details):
     page = movie_combined_details('matrix')
     data = parser.parse(page)['data']
-    assert re.match('^A computer hacker .* against its controllers.$', data['plot outline'])
+    assert re.match('^Thomas A\. Anderson is a man .* human rebellion.$', data['plot outline'])
 
 
 def test_plot_outline_none_should_be_excluded(movie_combined_details):

--- a/tests/test_http_movie_combined.py
+++ b/tests/test_http_movie_combined.py
@@ -519,6 +519,7 @@ def test_colors_single_should_be_a_list_of_color_types(movie_combined_details):
     assert data['color info'] == ['Color']
 
 
+@mark.skip('only a single color is listed now')
 def test_colors_multiple_should_be_a_list_of_color_types(movie_combined_details):
     page = movie_combined_details('pleasantville')
     data = parser.parse(page)['data']
@@ -531,6 +532,7 @@ def test_colors_single_with_notes_should_include_notes(movie_combined_details):
     assert data['color info'] == ['Color::(Eastmancolor)']
 
 
+@mark.skip('only a single color is listed now')
 def test_colors_multiple_with_notes_should_include_notes(movie_combined_details):
     page = movie_combined_details('if....')
     data = parser.parse(page)['data']


### PR DESCRIPTION
This PR fixes the following pieces of data in the movie combined details parser: genres, aspect ratio, plot outline, color info, sound mix, country and country codes, language and language codes, runtime. Note that the combined page lists only a single color and a single runtime for a movie now. And the MPAA rating is removed.