### PR TITLE
change movie combined page URL to end with /reference

### DIFF
--- a/imdb/parser/http/__init__.py
+++ b/imdb/parser/http/__init__.py
@@ -429,7 +429,7 @@ class IMDbHTTPAccessSystem(IMDbBase):
         return self.smProxy.search_movie_parser.parse(cont, results=results)['data']
 
     def get_movie_main(self, movieID):
-        cont = self._retrieve(self.urls['movie_main'] % movieID + 'combined')
+        cont = self._retrieve(self.urls['movie_main'] % movieID + 'reference')
         return self.mProxy.movie_parser.parse(cont, mdparse=self._mdparse)
 
     def get_movie_full_credits(self, movieID):

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -5,7 +5,7 @@ This module provides the classes (and the instances), used to parse the
 IMDb pages on the akas.imdb.com server about a movie.
 E.g., for Brian De Palma's "The Untouchables", the referred
 pages would be:
-    combined details:   http://akas.imdb.com/title/tt0094226/combined
+    combined details:   http://akas.imdb.com/title/tt0094226/reference
     plot summary:       http://akas.imdb.com/title/tt0094226/plotsummary
     ...and so on...
 

--- a/tests/test_http_movie_combined.py
+++ b/tests/test_http_movie_combined.py
@@ -9,7 +9,7 @@ from imdb.parser.http.movieParser import DOMHTMLMovieParser
 def movie_combined_details(url_opener, movies):
     """A function to retrieve the combined details page of a test movie."""
     def retrieve(movie_key):
-        url = movies[movie_key] + '/combined'
+        url = movies[movie_key] + '/reference'
         return url_opener.retrieve_unicode(url)
     return retrieve
 


### PR DESCRIPTION
Requests for movie combined details pages now redirect to ".../reference" instead of "/combined". This PR changes the URLs to avoid unnecessary redirects.