### PR TITLE
Fix og_title matching - empty dict for kinds other than movie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 .tox
 .coverage
 prof
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist/
 .coverage
 prof
 .vscode/settings.json
+.vscode/tags

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -159,7 +159,7 @@ def _toInt(val, replace=()):
 
 
 _re_og_title = re.compile(
-    r'(.*) \((?:(.+)(?= ))? ?(\d{4})(?:–(\d{4}| ))?\)',
+    r'(.*) \((?:(.+)(?= ))? ?(\d{4})(?:(–)(\d{4}| ))?\)',
     re.UNICODE
 )
 
@@ -177,11 +177,22 @@ def analyze_og_title(og_title):
             kind = kind.lower()
             kind = KIND_MAP.get(kind, kind)
         data['kind'] = kind
-        years = match.group(4)
-        if years is not None:
-            data['series years'] = years.strip()
+
+        year_separator = match.group(4)
+        # There is a year separator so assume an ongoing or ended series
+        if year_separator is not None:
+            end_year = match.group(5)
+            if end_year is not None:
+                data['series years'] = '%(year)d-%(end_year)s' % {
+                    'year': data['year'],
+                    'end_year': end_year.strip(),
+                }
+            elif kind.endswith('series'):
+                data['series years'] = '%(year)d-' % {'year': data['year']}
+        # No year separator and series, so assume that it ended the same year
         elif kind.endswith('series'):
             data['series years'] = '%(year)d-%(year)d' % {'year': data['year']}
+
     return data
 
 

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 parser.http.movieParser module (imdb package).
 
@@ -161,7 +159,7 @@ def _toInt(val, replace=()):
 
 
 _re_og_title = re.compile(
-    ur'(.*) \((?:(.+)(?= ))? ?(\d{4})(?:–(\d{4}| ))?\)',
+    r'(.*) \((?:(.+)(?= ))? ?(\d{4})(?:–(\d{4}| ))?\)',
     re.UNICODE
 )
 

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
 parser.http.movieParser module (imdb package).
 
@@ -158,7 +160,10 @@ def _toInt(val, replace=()):
         return None
 
 
-_re_og_title = re.compile(r'(.*) \(((.*) )?((\d{4})(-(\d{4}| ))?)\)')
+_re_og_title = re.compile(
+    ur'(.*) \((?:(.+)(?= ))? ?(\d{4})(?:–(\d{4}| ))?\)',
+    re.UNICODE
+)
 
 
 def analyze_og_title(og_title):
@@ -166,17 +171,17 @@ def analyze_og_title(og_title):
     match = _re_og_title.match(og_title)
     if match:
         data['title'] = match.group(1)
-        data['year'] = int(match.group(5))
-        kind = match.group(3)
+        data['year'] = int(match.group(3))
+        kind = match.group(2)
         if kind is None:
             kind = 'movie'
         else:
             kind = kind.lower()
             kind = KIND_MAP.get(kind, kind)
         data['kind'] = kind
-        years = match.group(6)
+        years = match.group(4)
         if years is not None:
-            data['series years'] = match.group(4).strip()
+            data['series years'] = years.strip()
         elif kind.endswith('series'):
             data['series years'] = '%(year)d-%(year)d' % {'year': data['year']}
     return data

--- a/imdb/parser/http/utils.py
+++ b/imdb/parser/http/utils.py
@@ -582,7 +582,6 @@ class DOMParserBase(object):
             return html_string
         # Remove silly &nbsp;&raquo; and &ndash; chars.
         html_string = html_string.replace(' \xbb', '')
-        html_string = html_string.replace('–', '-')
         html_string = html_string.replace('&ndash;', '-')
         try:
             preprocessors = self.preprocessors


### PR DESCRIPTION
Previous regexp didn't match TV series (and probably other kinds).

Sample `og_tilte` values
```
Agents of S.H.I.E.L.D. (TV Series 2013– )
Lost (TV 2004–2010)
The Matrix (1999)
```
  
Related to #103 

Before
```
In [7]: ia.get_movie('2364582')
Out[7]: <Movie id:2364582[http] title:_None_>
```

After
```
In [3]: ia.get_movie('2364582')
Out[3]: <Movie id:2364582[http] title:_"Agents of S.H.I.E.L.D." (2013)_>
```

Parsed title
```
In [6]: analyze_og_title(u'Agents of S.H.I.E.L.D. (TV Series 2013– )')
Out[6]: 
{'kind': u'tv series',
 'series years': u'',
 'title': u'Agents of S.H.I.E.L.D.',
 'year': 2013}

In [7]: analyze_og_title(u'Lost (TV Series 2004–2010)')
Out[7]: {'kind': u'tv series', 'series years': u'2010', 'title': u'Lost', 'year': 2004}

In [8]: analyze_og_title(u'The Matrix (1999)')
Out[8]: {'kind': 'movie', 'title': u'The Matrix', 'year': 1999}
```
  