### PR TITLE
Fix rank parsing in top/bottom parsers

### DIFF
--- a/imdb/parser/http/topBottomParser.py
+++ b/imdb/parser/http/topBottomParser.py
@@ -51,7 +51,7 @@ class DOMHTMLTop250Parser(DOMParserBase):
                     key=None,
                     multi=True,
                     path={
-                        self.ranktext: "./td[2]//text()",
+                        self.ranktext: "./td[2]/text()",
                         'rating': "./td[3]//strong//text()",
                         'title': "./td[2]//a//text()",
                         'year': "./td[2]//span//text()",

--- a/tests/test_http_chart_top.py
+++ b/tests/test_http_chart_top.py
@@ -28,7 +28,25 @@ def test_all_movies_should_have_rating_and_votes(chart_top):
         assert {'title', 'kind', 'year', 'rating', 'votes'}.issubset(set(movie.keys()))
 
 
-def test_chart_should_contain_correct_movie(chart_top):
+def test_ranks_should_proceed_in_order(chart_top):
     page = chart_top()
     data = parser.parse(page)['data']
-    assert '0133093' in dict(data)      # The Matrix
+    ranks = [m['top 250 rank'] for m_id, m in data]
+    assert ranks == list(range(1, 251))
+
+
+def test_chart_should_contain_matrix(chart_top):
+    page = chart_top()
+    data = parser.parse(page)['data']
+    assert '0133093' in dict(data)
+
+
+def test_shawshank_should_be_top_movie(chart_top):
+    page = chart_top()
+    data = parser.parse(page)['data']
+    top_id, top_movie = data[0]
+    assert top_id == '0111161'
+    assert top_movie['title'] == 'The Shawshank Redemption'
+    assert top_movie['year'] == 1994
+    assert top_movie['rating'] > 9
+    assert top_movie['votes'] > 1900000


### PR DESCRIPTION
This is a minor fix for getting rank values in top/bottom chart parsers. It also adds tests for checking some entry contents.