### PR TITLE
Fix title parsing for tv shows without a year

### DIFF
--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -170,7 +170,10 @@ def analyze_og_title(og_title):
     match = _re_og_title.match(og_title)
     if match:
         data['title'] = match.group(1)
-        data['year'] = int(match.group(3)) if match.group(3) else None
+
+        if match.group(3):
+            data['year'] = int(match.group(3))
+
         kind = match.group(2) or match.group(6)
         if kind is None:
             kind = 'movie'
@@ -191,12 +194,8 @@ def analyze_og_title(og_title):
             elif kind.endswith('series'):
                 data['series years'] = '%(year)d-' % {'year': data['year']}
         # No year separator and series, so assume that it ended the same year
-        elif kind.endswith('series'):
-            data['series years'] = (
-                '%(year)d-%(year)d' % {'year': data['year']}
-                if data['year'] else
-                None
-            )
+        elif kind.endswith('series') and 'year' in data:
+            data['series years'] = '%(year)d-%(year)d' % {'year': data['year']}
 
         if data['kind'] == 'episode' and data['title'][0] == '"':
             quote_end = data['title'].find('"', 1)

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -160,7 +160,7 @@ def _toInt(val, replace=()):
 
 
 _re_og_title = re.compile(
-    r'(.*) \((?:(.+)(?= ))? ?(\d{4})(?:(–)(\d{4}| ))?\)',
+    r'(.*) \((?:(?:(.+)(?= ))? ?(\d{4})(?:(–)(\d{4}| ))?|(.+))\)',
     re.UNICODE
 )
 
@@ -170,8 +170,8 @@ def analyze_og_title(og_title):
     match = _re_og_title.match(og_title)
     if match:
         data['title'] = match.group(1)
-        data['year'] = int(match.group(3))
-        kind = match.group(2)
+        data['year'] = int(match.group(3)) if match.group(3) else None
+        kind = match.group(2) or match.group(6)
         if kind is None:
             kind = 'movie'
         else:
@@ -192,7 +192,11 @@ def analyze_og_title(og_title):
                 data['series years'] = '%(year)d-' % {'year': data['year']}
         # No year separator and series, so assume that it ended the same year
         elif kind.endswith('series'):
-            data['series years'] = '%(year)d-%(year)d' % {'year': data['year']}
+            data['series years'] = (
+                '%(year)d-%(year)d' % {'year': data['year']}
+                if data['year'] else
+                None
+            )
 
         if data['kind'] == 'episode' and data['title'][0] == '"':
             quote_end = data['title'].find('"', 1)


### PR DESCRIPTION
Some tv shows don't have year in the `og:title` metadata field. This is a quick fix that handles those cases. Only downside is that the dict returned from `analyze_og_title` doesn't contain `year` nor `series years` so probably some tests will break? Not sure where those values are used.

Example of such tv show:  `'3336458': 'viva la madness'`