### PR TITLE
Imdbpy legacy redesign backport

### DIFF
--- a/docs/README.package
+++ b/docs/README.package
@@ -59,7 +59,7 @@ you can access movie data through the e-mail interface, etc. etc.
   Supported access systems  |  Aliases  |  Description
  ---------------------------+-----------+------------------------------------
   (default) 'http'          |   'web',  | information are fetched through
-                            |   'html'  | the http://akas.imdb.com web server.
+                            |   'html'  | the http://www.imdb.com web server.
  ---------------------------+-----------+------------------------------------
              'sql'          |   'db',   | information are fetched through
                             | 'database'| a SQL database (every database

--- a/docs/imdbpy.cfg
+++ b/docs/imdbpy.cfg
@@ -49,7 +49,7 @@ accessSystem = http
 ## Timeout for the connection to IMDb (30 seconds, by default).
 #timeout = 30 
 # Base url to access pages on the IMDb.com web server.
-#imdbURL_base = http://akas.imdb.com/
+#imdbURL_base = http://www.imdb.com/
 
 ## Parameters for the 'http' data access system.
 # Parser to use; can be a single value or a list of value separated by

--- a/imdb/Company.py
+++ b/imdb/Company.py
@@ -23,8 +23,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 from copy import deepcopy
 
-from imdb.utils import analyze_company_name, build_company_name, \
-                        flatten, _Container, cmpCompanies
+from imdb.utils import _Container
+from imdb.utils import analyze_company_name, build_company_name, cmpCompanies, flatten
 
 
 class Company(_Container):

--- a/imdb/Movie.py
+++ b/imdb/Movie.py
@@ -24,8 +24,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 from copy import deepcopy
 
 from imdb import linguistics
-from imdb.utils import analyze_title, build_title, canonicalTitle, \
-                        flatten, _Container, cmpMovies
+from imdb.utils import _Container
+from imdb.utils import analyze_title, build_title, canonicalTitle, cmpMovies, flatten
 
 
 class Movie(_Container):

--- a/imdb/__init__.py
+++ b/imdb/__init__.py
@@ -6,7 +6,7 @@ a person from the IMDb database.
 It can fetch data through different media (e.g.: the IMDb web pages,
 a SQL database, etc.)
 
-Copyright 2004-2017 Davide Alberani <da@erlug.linux.it>
+Copyright 2004-2018 Davide Alberani <da@erlug.linux.it>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -56,34 +56,34 @@ _aux_logger = logging.getLogger('imdbpy.aux')
 
 
 # URLs of the main pages for movies, persons, characters and queries.
-imdbURL_base = 'http://akas.imdb.com/'
+imdbURL_base = 'http://www.imdb.com/'
 
 # NOTE: the urls below will be removed in a future version.
 #       please use the values in the 'urls' attribute
 #       of the IMDbBase subclass instance.
-# http://akas.imdb.com/title/
+# http://www.imdb.com/title/
 imdbURL_movie_base = '%stitle/' % imdbURL_base
-# http://akas.imdb.com/title/tt%s/
+# http://www.imdb.com/title/tt%s/
 imdbURL_movie_main = imdbURL_movie_base + 'tt%s/'
-# http://akas.imdb.com/name/
+# http://www.imdb.com/name/
 imdbURL_person_base = '%sname/' % imdbURL_base
-# http://akas.imdb.com/name/nm%s/
+# http://www.imdb.com/name/nm%s/
 imdbURL_person_main = imdbURL_person_base + 'nm%s/'
-# http://akas.imdb.com/character/
+# http://www.imdb.com/character/
 imdbURL_character_base = '%scharacter/' % imdbURL_base
-# http://akas.imdb.com/character/ch%s/
+# http://www.imdb.com/character/ch%s/
 imdbURL_character_main = imdbURL_character_base + 'ch%s/'
-# http://akas.imdb.com/company/
+# http://www.imdb.com/company/
 imdbURL_company_base = '%scompany/' % imdbURL_base
-# http://akas.imdb.com/company/co%s/
+# http://www.imdb.com/company/co%s/
 imdbURL_company_main = imdbURL_company_base + 'co%s/'
-# http://akas.imdb.com/keyword/%s/
+# http://www.imdb.com/keyword/%s/
 imdbURL_keyword_main = imdbURL_base + 'keyword/%s/'
-# http://akas.imdb.com/chart/top
+# http://www.imdb.com/chart/top
 imdbURL_top250 = imdbURL_base + 'chart/top'
-# http://akas.imdb.com/chart/bottom
+# http://www.imdb.com/chart/bottom
 imdbURL_bottom100 = imdbURL_base + 'chart/bottom'
-# http://akas.imdb.com/find?%s
+# http://www.imdb.com/find?%s
 imdbURL_find = imdbURL_base + 'find?%s'
 
 # Name of the configuration file.
@@ -293,30 +293,30 @@ class IMDbBase:
             imdbURL_base = 'http://%s' % imdbURL_base
         if not imdbURL_base.endswith('/'):
             imdbURL_base = '%s/' % imdbURL_base
-        # http://akas.imdb.com/title/
-        imdbURL_movie_base='%stitle/' % imdbURL_base
-        # http://akas.imdb.com/title/tt%s/
-        imdbURL_movie_main=imdbURL_movie_base + 'tt%s/'
-        # http://akas.imdb.com/name/
-        imdbURL_person_base='%sname/' % imdbURL_base
-        # http://akas.imdb.com/name/nm%s/
-        imdbURL_person_main=imdbURL_person_base + 'nm%s/'
-        # http://akas.imdb.com/character/
-        imdbURL_character_base='%scharacter/' % imdbURL_base
-        # http://akas.imdb.com/character/ch%s/
-        imdbURL_character_main=imdbURL_character_base + 'ch%s/'
-        # http://akas.imdb.com/company/
-        imdbURL_company_base='%scompany/' % imdbURL_base
-        # http://akas.imdb.com/company/co%s/
-        imdbURL_company_main=imdbURL_company_base + 'co%s/'
-        # http://akas.imdb.com/keyword/%s/
-        imdbURL_keyword_main=imdbURL_base + 'keyword/%s/'
-        # http://akas.imdb.com/chart/top
-        imdbURL_top250=imdbURL_base + 'chart/top'
-        # http://akas.imdb.com/chart/bottom
-        imdbURL_bottom100=imdbURL_base + 'chart/bottom'
-        # http://akas.imdb.com/find?%s
-        imdbURL_find=imdbURL_base + 'find?%s'
+        # http://www.imdb.com/title/
+        imdbURL_movie_base = '%stitle/' % imdbURL_base
+        # http://www.imdb.com/title/tt%s/
+        imdbURL_movie_main = imdbURL_movie_base + 'tt%s/'
+        # http://www.imdb.com/name/
+        imdbURL_person_base = '%sname/' % imdbURL_base
+        # http://www.imdb.com/name/nm%s/
+        imdbURL_person_main = imdbURL_person_base + 'nm%s/'
+        # http://www.imdb.com/character/
+        imdbURL_character_base = '%scharacter/' % imdbURL_base
+        # http://www.imdb.com/character/ch%s/
+        imdbURL_character_main = imdbURL_character_base + 'ch%s/'
+        # http://www.imdb.com/company/
+        imdbURL_company_base = '%scompany/' % imdbURL_base
+        # http://www.imdb.com/company/co%s/
+        imdbURL_company_main = imdbURL_company_base + 'co%s/'
+        # http://www.imdb.com/keyword/%s/
+        imdbURL_keyword_main = imdbURL_base + 'keyword/%s/'
+        # http://www.imdb.com/chart/top
+        imdbURL_top250 = imdbURL_base + 'chart/top'
+        # http://www.imdb.com/chart/bottom
+        imdbURL_bottom100 = imdbURL_base + 'chart/bottom'
+        # http://www.imdb.com/find?%s
+        imdbURL_find = imdbURL_base + 'find?%s'
         self.urls = dict(
             movie_base=imdbURL_movie_base,
             movie_main=imdbURL_movie_main,
@@ -834,9 +834,7 @@ class IMDbBase:
         raise NotImplementedError('override this method')
 
     def _searchIMDb(self, kind, ton, title_kind=None):
-        """Search the IMDb akas server for the given title or name."""
-        # The Exact Primary search system has gone AWOL, so we resort
-        # to the mobile search. :-/
+        """Search the IMDb www server for the given title or name."""
         if not ton:
             return None
         ton = ton.strip('"')

--- a/imdb/__init__.py
+++ b/imdb/__init__.py
@@ -51,6 +51,7 @@ import imdb._logging
 from imdb._exceptions import IMDbError, IMDbDataAccessError, IMDbParserError
 from imdb.utils import build_title, build_name, build_company_name
 
+_imdb_logger = logging.getLogger('imdbpy')
 _aux_logger = logging.getLogger('imdbpy.aux')
 
 
@@ -173,9 +174,7 @@ def IMDb(accessSystem=None, *arguments, **keywords):
             kwds.update(keywords)
             keywords = kwds
         except Exception as e:
-            import logging
-            logging.getLogger('imdbpy').warn('Unable to read configuration' \
-                                            ' file; complete error: %s' % e)
+            _imdb_logger.warn('Unable to read configuration file; complete error: %s' % e)
             # It just LOOKS LIKE a bad habit: we tried to read config
             # options from some files, but something is gone horribly
             # wrong: ignore everything and pretend we were called with
@@ -191,8 +190,7 @@ def IMDb(accessSystem=None, *arguments, **keywords):
             import logging.config
             logging.config.fileConfig(os.path.expanduser(logCfg))
         except Exception as e:
-            logging.getLogger('imdbpy').warn('unable to read logger ' \
-                                            'config: %s' % e)
+            _imdb_logger.warn('unable to read logger config: %s' % e)
     if accessSystem in ('httpThin', 'webThin', 'htmlThin'):
         logging.warn('httpThin was removed since IMDbPY 4.8')
         accessSystem = 'http'
@@ -256,9 +254,6 @@ class IMDbBase:
     # The name of the preferred access system (MUST be overridden
     # in the subclasses).
     accessSystem = 'UNKNOWN'
-
-    # Top-level logger for IMDbPY.
-    _imdb_logger = logging.getLogger('imdbpy')
 
     # Whether to re-raise caught exceptions or not.
     _reraise_exceptions = False
@@ -740,16 +735,15 @@ class IMDbBase:
             mopID = mop.companyID
             prefix = 'company'
         else:
-            raise IMDbError('object ' + repr(mop) + \
-                    ' is not a Movie, Person, Character or Company instance')
+            raise IMDbError('object ' + repr(mop) +
+                            ' is not a Movie, Person, Character or Company instance')
         if mopID is None:
             # XXX: enough?  It's obvious that there are Characters
             #      objects without characterID, so I think they should
             #      just do nothing, when an i.update(character) is tried.
             if prefix == 'character':
                 return
-            raise IMDbDataAccessError( \
-                'the supplied object has null movieID, personID or companyID')
+            raise IMDbDataAccessError('supplied object has null movieID, personID or companyID')
         if mop.accessSystem == self.accessSystem:
             aSystem = self
         else:
@@ -773,21 +767,22 @@ class IMDbBase:
                 continue
             if not i:
                 continue
-            self._imdb_logger.debug('retrieving "%s" info set', i)
+            _imdb_logger.debug('retrieving "%s" info set', i)
             try:
                 method = getattr(aSystem, 'get_%s_%s' %
                                     (prefix, i.replace(' ', '_')))
             except AttributeError:
-                self._imdb_logger.error('unknown information set "%s"', i)
+                _imdb_logger.error('unknown information set "%s"', i)
                 # Keeps going.
                 method = lambda *x: {}
             try:
                 ret = method(mopID)
-            except Exception as e:
-                self._imdb_logger.critical('caught an exception retrieving ' \
-                                    'or parsing "%s" info set for mopID ' \
-                                    '"%s" (accessSystem: %s)',
-                                    i, mopID, mop.accessSystem, exc_info=True)
+            except Exception:
+                _imdb_logger.critical(
+                    'caught an exception retrieving or parsing "%s" info set'
+                    ' for mopID "%s" (accessSystem: %s)',
+                    i, mopID, mop.accessSystem, exc_info=True
+                )
                 ret = {}
                 # If requested by the user, reraise the exception.
                 if self._reraise_exceptions:
@@ -948,8 +943,8 @@ class IMDbBase:
             else:
                 imdbID = aSystem.company2imdbID(build_company_name(mop))
         else:
-            raise IMDbError('object ' + repr(mop) + \
-                        ' is not a Movie, Person or Character instance')
+            raise IMDbError('object ' + repr(mop) +
+                            ' is not a Movie, Person or Character instance')
         return imdbID
 
     def get_imdbURL(self, mop):
@@ -967,8 +962,8 @@ class IMDbBase:
         elif isinstance(mop, Company.Company):
             url_firstPart = imdbURL_company_main
         else:
-            raise IMDbError('object ' + repr(mop) + \
-                        ' is not a Movie, Person, Character or Company instance')
+            raise IMDbError('object ' + repr(mop) +
+                            ' is not a Movie, Person, Character or Company instance')
         return url_firstPart % imdbID
 
     def get_special_methods(self):

--- a/imdb/_logging.py
+++ b/imdb/_logging.py
@@ -32,8 +32,9 @@ LEVELS = {'debug': logging.DEBUG,
 
 imdbpyLogger = logging.getLogger('imdbpy')
 imdbpyStreamHandler = logging.StreamHandler()
-imdbpyFormatter = logging.Formatter('%(asctime)s %(levelname)s [%(name)s]' \
-                                    ' %(pathname)s:%(lineno)d: %(message)s')
+imdbpyFormatter = logging.Formatter(
+    '%(asctime)s %(levelname)s [%(name)s] %(pathname)s:%(lineno)d: %(message)s'
+)
 imdbpyStreamHandler.setFormatter(imdbpyFormatter)
 imdbpyLogger.addHandler(imdbpyStreamHandler)
 

--- a/imdb/helpers.py
+++ b/imdb/helpers.py
@@ -269,8 +269,8 @@ for k, v in {'lt':u'<','gt':u'>','amp':u'&','quot':u'"','apos':u'\''}.items():
     everyentcharrefs[k] = v
     everyentcharrefs['#%s' % ord(v)] = v
 everyentcharrefsget = everyentcharrefs.get
-re_everyentcharrefs = re.compile('&(%s|\#160|\#\d{1,5});' %
-                            '|'.join(map(re.escape, everyentcharrefs)))
+re_everyentcharrefs = re.compile('&(%s|\#160|\#\d{1,5});' % '|'.join(map(re.escape,
+                                                                         everyentcharrefs)))
 re_everyentcharrefssub = re_everyentcharrefs.sub
 
 def _replAllXMLRef(match):

--- a/imdb/parser/http/__init__.py
+++ b/imdb/parser/http/__init__.py
@@ -69,8 +69,8 @@ class _ModuleProxy:
         """Initialize a proxy for the given module; defaultKeys, if set,
         muste be a dictionary of values to set for instanced objects."""
         if oldParsers or fallBackToNew:
-            _aux_logger.warn('The old set of parsers was removed; falling ' \
-                            'back to the new parsers.')
+            _aux_logger.warn('The old set of parsers was removed;'
+                             ' falling back to the new parsers.')
         self.useModule = useModule
         if defaultKeys is None:
             defaultKeys = {}
@@ -239,9 +239,10 @@ class IMDbURLopener(FancyURLopener):
         if encode is None:
             encode = 'latin_1'
             # The detection of the encoding is error prone...
-            self._logger.warn('Unable to detect the encoding of the retrieved '
-                        'page [%s]; falling back to default latin1.', encode)
-        ##print unicode(content, encode, 'replace').encode('utf8')
+            self._logger.warn('Unable to detect the encoding of the retrieved page [%s];'
+                              ' falling back to default utf8.', encode)
+        if isinstance(content, unicode):
+            return content
         return unicode(content, encode, 'replace')
 
     def http_error_default(self, url, fp, errcode, errmsg, headers):
@@ -290,8 +291,8 @@ class IMDbHTTPAccessSystem(IMDbBase):
         self._getRefs = True
         self._mdparse = False
         if isThin:
-            self._http_logger.warn('"httpThin" access system no longer ' +
-                    'supported; "http" used automatically', exc_info=False)
+            self._http_logger.warn('"httpThin" access system no longer supported;'
+                                   ' "http" used automatically', exc_info=False)
             self.isThin = 0
             if self.accessSystem in ('httpThin', 'webThin', 'htmlThin'):
                 self.accessSystem = 'http'

--- a/imdb/parser/http/__init__.py
+++ b/imdb/parser/http/__init__.py
@@ -213,9 +213,9 @@ class IMDbURLopener(FancyURLopener):
             if server_encode is None and content:
                 begin_h = content.find('text/html; charset=')
                 if begin_h != -1:
-                    end_h = content[19+begin_h:].find('"')
+                    end_h = content[19 + begin_h:].find('"')
                     if end_h != -1:
-                        server_encode = content[19+begin_h:19+begin_h+end_h]
+                        server_encode = content[19 + begin_h:19 + begin_h + end_h]
             if server_encode:
                 try:
                     if lookup(server_encode):

--- a/imdb/parser/http/__init__.py
+++ b/imdb/parser/http/__init__.py
@@ -814,7 +814,7 @@ class IMDbHTTPAccessSystem(IMDbBase):
     def _search_keyword(self, keyword, results):
         # XXX: the IMDb web server seems to have some serious problem with
         #      non-ascii keyword.
-        #      E.g.: http://akas.imdb.com/keyword/fianc%E9/
+        #      E.g.: http://www.imdb.com/keyword/fianc%E9/
         #      will return a 500 Internal Server Error: Redirect Recursion.
         keyword = keyword.encode('utf8', 'ignore')
         try:

--- a/imdb/parser/http/__init__.py
+++ b/imdb/parser/http/__init__.py
@@ -506,7 +506,7 @@ class IMDbHTTPAccessSystem(IMDbBase):
         return self.smProxy.search_movie_parser.parse(cont, results=results)['data']
 
     def get_movie_main(self, movieID):
-        cont = self._retrieve(self.urls['movie_main'] % movieID + 'combined')
+        cont = self._retrieve(self.urls['movie_main'] % movieID + 'reference')
         return self.mProxy.movie_parser.parse(cont, mdparse=self._mdparse)
 
     def get_movie_full_credits(self, movieID):

--- a/imdb/parser/http/characterParser.py
+++ b/imdb/parser/http/characterParser.py
@@ -2,7 +2,7 @@
 parser.http.characterParser module (imdb package).
 
 This module provides the classes (and the instances), used to parse
-the IMDb pages on the akas.imdb.com server about a character.
+the IMDb pages on the www.imdb.com server about a character.
 E.g., for "Jesse James" the referred pages would be:
     main details:   http://www.imdb.com/character/ch0000001/
     biography:      http://www.imdb.com/character/ch0000001/bio
@@ -37,7 +37,7 @@ _personIDs = re.compile(r'/name/nm([0-9]{7})')
 class DOMHTMLCharacterMaindetailsParser(DOMHTMLMaindetailsParser):
     """Parser for the "filmography" page of a given character.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -101,7 +101,7 @@ class DOMHTMLCharacterMaindetailsParser(DOMHTMLMaindetailsParser):
 class DOMHTMLCharacterBioParser(DOMParserBase):
     """Parser for the "biography" page of a given character.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -146,7 +146,7 @@ class DOMHTMLCharacterBioParser(DOMParserBase):
 class DOMHTMLCharacterQuotesParser(DOMParserBase):
     """Parser for the "quotes" page of a given character.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:

--- a/imdb/parser/http/companyParser.py
+++ b/imdb/parser/http/companyParser.py
@@ -2,9 +2,9 @@
 parser.http.companyParser module (imdb package).
 
 This module provides the classes (and the instances), used to parse
-the IMDb pages on the akas.imdb.com server about a company.
+the IMDb pages on the www.imdb.com server about a company.
 E.g., for "Columbia Pictures [us]" the referred page would be:
-    main details:   http://akas.imdb.com/company/co0071509/
+    main details:   http://www.imdb.com/company/co0071509/
 
 Copyright 2008-2017 Davide Alberani <da@erlug.linux.it>
           2008-2017 H. Turgut Uyar <uyar@tekir.org>
@@ -34,7 +34,7 @@ from imdb.utils import analyze_company_name
 class DOMCompanyParser(DOMParserBase):
     """Parser for the main page of a given company.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:

--- a/imdb/parser/http/companyParser.py
+++ b/imdb/parser/http/companyParser.py
@@ -44,31 +44,38 @@ class DOMCompanyParser(DOMParserBase):
     _containsObjects = True
 
     extractors = [
-            Extractor(label='name',
-                        path="//title",
-                        attrs=Attribute(key='name',
-                            path="./text()",
-                        postprocess=lambda x: \
-                                analyze_company_name(x, stripNotes=True))),
+        Extractor(
+            label='name',
+            path="//title",
+            attrs=Attribute(
+                key='name',
+                path="./text()",
+                postprocess=lambda x: analyze_company_name(x, stripNotes=True)
+            )
+        ),
 
-            Extractor(label='filmography',
-                        group="//b/a[@name]",
-                        group_key="./text()",
-                        group_key_normalize=lambda x: x.lower(),
-                        path="../following-sibling::ol[1]/li",
-                        attrs=Attribute(key=None,
-                            multi=True,
-                            path={
-                                'link': "./a[1]/@href",
-                                'title': "./a[1]/text()",
-                                'year': "./text()[1]"
-                                },
-                            postprocess=lambda x:
-                                build_movie(u'%s %s' % \
-                                (x.get('title'), x.get('year').strip()),
-                                movieID=analyze_imdbid(x.get('link') or u''),
-                                _parsingCompany=True))),
-            ]
+        Extractor(
+            label='filmography',
+            group="//b/a[@name]",
+            group_key="./text()",
+            group_key_normalize=lambda x: x.lower(),
+            path="../following-sibling::ol[1]/li",
+            attrs=Attribute(
+                key=None,
+                multi=True,
+                path={
+                    'link': "./a[1]/@href",
+                    'title': "./a[1]/text()",
+                    'year': "./text()[1]"
+                },
+                postprocess=lambda x: build_movie(
+                    '%s %s' % (x.get('title'), x.get('year').strip()),
+                    movieID=analyze_imdbid(x.get('link') or u''),
+                    _parsingCompany=True
+                )
+            )
+        )
+    ]
 
     preprocessors = [
         (re.compile('(<b><a name=)', re.I), r'</p>\1')

--- a/imdb/parser/http/companyParser.py
+++ b/imdb/parser/http/companyParser.py
@@ -6,8 +6,8 @@ the IMDb pages on the akas.imdb.com server about a company.
 E.g., for "Columbia Pictures [us]" the referred page would be:
     main details:   http://akas.imdb.com/company/co0071509/
 
-Copyright 2008-2009 Davide Alberani <da@erlug.linux.it>
-          2008 H. Turgut Uyar <uyar@tekir.org>
+Copyright 2008-2017 Davide Alberani <da@erlug.linux.it>
+          2008-2017 H. Turgut Uyar <uyar@tekir.org>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/imdb/parser/http/companyParser.py
+++ b/imdb/parser/http/companyParser.py
@@ -46,7 +46,7 @@ class DOMCompanyParser(DOMParserBase):
     extractors = [
         Extractor(
             label='name',
-            path="//title",
+            path="//h1/span[@class='display-title ']",  # note the extra trailing space in class
             attrs=Attribute(
                 key='name',
                 path="./text()",

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
 parser.http.movieParser module (imdb package).
 
@@ -156,7 +158,10 @@ def _toInt(val, replace=()):
         return None
 
 
-_re_og_title = re.compile(r'(.*) \(((.*) )?((\d{4})(-(\d{4}| ))?)\)')
+_re_og_title = re.compile(
+    ur'(.*) \((?:(.+)(?= ))? ?(\d{4})(?:–(\d{4}| ))?\)',
+    re.UNICODE
+)
 
 
 def analyze_og_title(og_title):
@@ -164,17 +169,17 @@ def analyze_og_title(og_title):
     match = _re_og_title.match(og_title)
     if match:
         data['title'] = match.group(1)
-        data['year'] = int(match.group(5))
-        kind = match.group(3)
+        data['year'] = int(match.group(3))
+        kind = match.group(2)
         if kind is None:
             kind = 'movie'
         else:
             kind = kind.lower()
             kind = KIND_MAP.get(kind, kind)
         data['kind'] = kind
-        years = match.group(6)
+        years = match.group(4)
         if years is not None:
-            data['series years'] = match.group(4).strip()
+            data['series years'] = years.strip()
         elif kind.endswith('series'):
             data['series years'] = '%(year)d-%(year)d' % {'year': data['year']}
     return data

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -507,7 +507,7 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='previous episode',
-            path=".//a[@title='Previous Episode']",
+            path=".//span[@class='titlereference-overview-episodes-links']//a[contains(text(), 'Previous')]",
             attrs=Attribute(
                 key='previous episode',
                 path="./@href",
@@ -517,7 +517,7 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='next episode',
-            path=".//a[@title='Next Episode']",
+            path=".//span[@class='titlereference-overview-episodes-links']//a[contains(text(), 'Next')]",
             attrs=Attribute(
                 key='next episode',
                 path="./@href",

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -251,11 +251,11 @@ class DOMHTMLMovieParser(DOMParserBase):
                     path=".//td[starts-with(text(), 'Aspect')]/..//li/text()",
                     postprocess=lambda x: x.strip()
                 ),
-                Attribute(
-                    key="mpaa",
-                    path=".//td/a[starts-with(text(), 'MPAA')]/../../div/text()",
-                    postprocess=lambda x: x.strip()
-                ),
+                # Attribute(
+                #     key="mpaa",
+                #     path=".//td/a[starts-with(text(), 'MPAA')]/../../div/text()",
+                #     postprocess=lambda x: x.strip()
+                # ),
                 Attribute(
                     key="countries",
                     path=".//td[starts-with(text(), 'Countr')]/.."

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -2641,6 +2641,8 @@ _OBJECTS = {
     'ratings_parser': ((DOMHTMLRatingsParser,), None),
     'officialsites_parser': ((DOMHTMLOfficialsitesParser,), None),
     'criticrev_parser': ((DOMHTMLCriticReviewsParser,), {'kind': 'critic reviews'}),
+    'reviews_parser': ((DOMHTMLReviewsParser,), {'kind': 'reviews'}),
+    'externalsites_parser': ((DOMHTMLOfficialsitesParser,), None),
     'externalrev_parser': ((DOMHTMLOfficialsitesParser,), {'kind': 'external reviews'}),
     'misclinks_parser': ((DOMHTMLOfficialsitesParser,), {'kind': 'misc links'}),
     'soundclips_parser': ((DOMHTMLOfficialsitesParser,), {'kind': 'sound clips'}),

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -269,6 +269,27 @@ class DOMHTMLMovieParser(DOMParserBase):
         ),
 
         Extractor(
+            label='language',
+            path="//td[starts-with(text(), 'Language')]/..//li/a",
+            attrs=Attribute(
+                key='language',
+                path="./text()",
+                multi=True
+            )
+        ),
+
+        Extractor(
+            label='language codes',
+            path="//td[starts-with(text(), 'Language')]/..//li/a",
+            attrs=Attribute(
+                key='language codes',
+                path="./@href",
+                multi=True,
+                postprocess=lambda x: x.split('/')[2].strip()
+            )
+        ),
+
+        Extractor(
             label='color info',
             path="//td[starts-with(text(), 'Color')]/..//li/a",
             attrs=Attribute(
@@ -309,11 +330,6 @@ class DOMHTMLMovieParser(DOMParserBase):
                 #     path=".//td/a[starts-with(text(), 'MPAA')]/../../div/text()",
                 #     postprocess=lambda x: x.strip()
                 # ),
-                Attribute(
-                    key="language",
-                    path=".//td[starts-with(text(), 'Language')]/..//text()",
-                    postprocess=makeSplitter('Language:')
-                ),
                 # Collects akas not encosed in <i> tags.
                 Attribute(
                     key='other akas',
@@ -350,18 +366,6 @@ class DOMHTMLMovieParser(DOMParserBase):
                     path=".//td[starts-with(text(), 'TV Series')]/..//a/text()"
                 )
             ]
-        ),
-
-        Extractor(
-            label='language codes',
-            path="//td[starts-with(text(), 'Language')]/.."
-                 "//a[starts-with(@href, '/language/')]",
-            attrs=Attribute(
-                key='language codes',
-                multi=True,
-                path="./@href",
-                postprocess=lambda x: x.split('/')[2].strip()
-            )
         ),
 
         Extractor(

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -193,6 +193,10 @@ def analyze_og_title(og_title):
         elif kind.endswith('series'):
             data['series years'] = '%(year)d-%(year)d' % {'year': data['year']}
 
+        if data['kind'] == 'episode' and data['title'][0] == '"':
+            quote_end = data['title'].find('"', 1)
+            data['title'] = data['title'][quote_end + 1:].strip()
+
     return data
 
 

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -516,7 +516,7 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='number of seasons',
-            path=".//section[@class='titlereference-section-overview']/div/a[1]",
+            path=".//span[@class='titlereference-overview-years-links']/../a[1]",
             attrs=Attribute(
                 key='number of seasons',
                 path="./text()",
@@ -708,7 +708,7 @@ class DOMHTMLMovieParser(DOMParserBase):
             data['runtimes'] = [x.replace(' min', u'')
                                 for x in data['runtimes']]
         if 'number of seasons' in data:
-            data['seasons'] = [i for i in range(1, data['number of seasons'] + 1)]
+            data['seasons'] = [unicode(i) for i in range(1, data['number of seasons'] + 1)]
             # data['number of seasons'] = seasons[-1] if seasons else len(data['seasons'])
         if 'original air date' in data:
             oid = self.re_space.sub(' ', data['original air date']).strip()

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -763,6 +763,8 @@ class DOMHTMLMovieParser(DOMParserBase):
                 data['rating'] = float(data['rating'].replace('/10', ''))
             except (TypeError, ValueError):
                 pass
+            if data['rating'] == 0:
+                del data['rating']
         if 'votes' in data:
             try:
                 votes = data['votes'].replace('(', '').replace(')', '').replace(',', '').replace('votes', '')

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -4,11 +4,11 @@
 parser.http.movieParser module (imdb package).
 
 This module provides the classes (and the instances), used to parse the
-IMDb pages on the akas.imdb.com server about a movie.
+IMDb pages on the www.imdb.com server about a movie.
 E.g., for Brian De Palma's "The Untouchables", the referred
 pages would be:
-    combined details:   http://akas.imdb.com/title/tt0094226/reference
-    plot summary:       http://akas.imdb.com/title/tt0094226/plotsummary
+    combined details:   http://www.imdb.com/title/tt0094226/reference
+    plot summary:       http://www.imdb.com/title/tt0094226/plotsummary
     ...and so on...
 
 Copyright 2004-2017 Davide Alberani <da@erlug.linux.it>
@@ -228,7 +228,7 @@ class DOMHTMLMovieParser(DOMParserBase):
     """Parser for the "combined details" (and if instance.mdparse is
     True also for the "main details") page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -840,7 +840,7 @@ def _process_plotsummary(x):
 class DOMHTMLPlotParser(DOMParserBase):
     """Parser for the "plot summary" page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a 'plot' key, containing a list
     of string with the structure: 'summary::summary_author <author@email>'.
 
@@ -898,7 +898,7 @@ def _process_award(x):
 class DOMHTMLAwardsParser(DOMParserBase):
     """Parser for the "awards" page of a given person or movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -1017,7 +1017,7 @@ class DOMHTMLAwardsParser(DOMParserBase):
 class DOMHTMLTaglinesParser(DOMParserBase):
     """Parser for the "taglines" page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -1052,7 +1052,7 @@ class DOMHTMLTaglinesParser(DOMParserBase):
 class DOMHTMLKeywordsParser(DOMParserBase):
     """Parser for the "keywords" page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -1075,7 +1075,7 @@ class DOMHTMLKeywordsParser(DOMParserBase):
 class DOMHTMLAlternateVersionsParser(DOMParserBase):
     """Parser for the "alternate versions" page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -1101,7 +1101,7 @@ class DOMHTMLAlternateVersionsParser(DOMParserBase):
 class DOMHTMLTriviaParser(DOMParserBase):
     """Parser for the "trivia" page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -1191,7 +1191,7 @@ class DOMHTMLSoundtrackParser(DOMParserBase):
 class DOMHTMLCrazyCreditsParser(DOMParserBase):
     """Parser for the "crazy credits" page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -1224,7 +1224,7 @@ def _process_goof(x):
 class DOMHTMLGoofsParser(DOMParserBase):
     """Parser for the "goofs" page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -1254,7 +1254,7 @@ class DOMHTMLGoofsParser(DOMParserBase):
 class DOMHTMLQuotesParser(DOMParserBase):
     """Parser for the "memorable quotes" page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -1318,7 +1318,7 @@ class DOMHTMLQuotesParser(DOMParserBase):
 class DOMHTMLReleaseinfoParser(DOMParserBase):
     """Parser for the "release dates" page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -1403,7 +1403,7 @@ class DOMHTMLReleaseinfoParser(DOMParserBase):
 class DOMHTMLRatingsParser(DOMParserBase):
     """Parser for the "user ratings" page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -1528,7 +1528,7 @@ class DOMHTMLRatingsParser(DOMParserBase):
 class DOMHTMLEpisodesRatings(DOMParserBase):
     """Parser for the "episode ratings ... by date" page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -1614,7 +1614,7 @@ def _normalize_href(href):
 class DOMHTMLCriticReviewsParser(DOMParserBase):
     """Parser for the "critic reviews" pages of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -1647,7 +1647,7 @@ class DOMHTMLCriticReviewsParser(DOMParserBase):
 class DOMHTMLReviewsParser(DOMParserBase):
     """Parser for the "reviews" pages of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -1707,7 +1707,7 @@ class DOMHTMLReviewsParser(DOMParserBase):
 class DOMHTMLFullCreditsParser(DOMParserBase):
     """Parser for the "full credits" (series cast section) page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -1747,7 +1747,7 @@ class DOMHTMLOfficialsitesParser(DOMParserBase):
     reviews", "miscellaneous links", "sound clips", "video clips" and
     "photographs" pages of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -1779,7 +1779,7 @@ class DOMHTMLOfficialsitesParser(DOMParserBase):
 class DOMHTMLConnectionParser(DOMParserBase):
     """Parser for the "connections" page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -1836,7 +1836,7 @@ class DOMHTMLConnectionParser(DOMParserBase):
 class DOMHTMLLocationsParser(DOMParserBase):
     """Parser for the "locations" page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -1869,7 +1869,7 @@ class DOMHTMLTechParser(DOMParserBase):
     """Parser for the "technical", "publicity" (for people) and "contacts" (for people)
     pages of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -1932,7 +1932,7 @@ class DOMHTMLTechParser(DOMParserBase):
 class DOMHTMLBusinessParser(DOMParserBase):
     """Parser for the "business" and "literature" pages of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -1975,7 +1975,7 @@ class DOMHTMLBusinessParser(DOMParserBase):
 class DOMHTMLRecParser(DOMParserBase):
     """Parser for the "recommendations" page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -2021,7 +2021,7 @@ class DOMHTMLRecParser(DOMParserBase):
 class DOMHTMLNewsParser(DOMParserBase):
     """Parser for the "news" page of a given movie or person.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -2102,7 +2102,7 @@ def _parse_review(x):
 class DOMHTMLSeasonEpisodesParser(DOMParserBase):
     """Parser for the "episode list" page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -2275,7 +2275,7 @@ def _build_episode(x):
 class DOMHTMLEpisodesParser(DOMParserBase):
     """Parser for the "episode list" page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -2416,7 +2416,7 @@ class DOMHTMLEpisodesParser(DOMParserBase):
 class DOMHTMLEpisodesCastParser(DOMHTMLEpisodesParser):
     """Parser for the "episodes cast" page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -2431,7 +2431,7 @@ class DOMHTMLEpisodesCastParser(DOMHTMLEpisodesParser):
 class DOMHTMLFaqsParser(DOMParserBase):
     """Parser for the "FAQ" page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -2472,7 +2472,7 @@ class DOMHTMLFaqsParser(DOMParserBase):
 class DOMHTMLAiringParser(DOMParserBase):
     """Parser for the "airing" page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -2564,7 +2564,7 @@ class DOMHTMLAiringParser(DOMParserBase):
 class DOMHTMLSynopsisParser(DOMParserBase):
     """Parser for the "synopsis" page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -2591,7 +2591,7 @@ class DOMHTMLSynopsisParser(DOMParserBase):
 class DOMHTMLParentsGuideParser(DOMParserBase):
     """Parser for the "parents guide" page of a given movie.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -248,6 +248,17 @@ class DOMHTMLMovieParser(DOMParserBase):
         ),
 
         Extractor(
+            label='runtimes',
+            path="//td[starts-with(text(), 'Runtime')]/..//li",
+            attrs=Attribute(
+                key='runtimes',
+                path="./text()",
+                multi=True,
+                postprocess=lambda x: x.strip().replace(' min', '')
+            )
+        ),
+
+        Extractor(
             label='countries',
             path="//td[starts-with(text(), 'Countr')]/..//li/a",
             attrs=Attribute(
@@ -337,11 +348,6 @@ class DOMHTMLMovieParser(DOMParserBase):
                     postprocess=makeSplitter(
                         sep='::', origNotesSep='" - ', newNotesSep='::', strip='"'
                     )
-                ),
-                Attribute(
-                    key='runtimes',
-                    path=".//td[starts-with(text(), 'Runtime')]/..//ul//text()",
-                    postprocess=makeSplitter()
                 ),
                 Attribute(
                     key='certificates',

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -57,13 +57,13 @@ _SECT_CONV = {
     'second unit director or assistant director': 'assistant director',
     'costume and wardrobe department': 'costume department',
     'sound department': 'sound crew',
-    'stunts':   'stunt performer',
+    'stunts': 'stunt performer',
     'other crew': 'miscellaneous crew',
     'also known as': 'akas',
-    'country':  'countries',
-    'runtime':  'runtimes',
+    'country': 'countries',
+    'runtime': 'runtimes',
     'language': 'languages',
-    'certification':    'certificates',
+    'certification': 'certificates',
     'genre': 'genres',
     'created': 'creator',
     'creators': 'creator',
@@ -830,7 +830,7 @@ class DOMHTMLAwardsParser(DOMParserBase):
             del col.attrib['rowspan']
             position = len(self.xpath(col, "./preceding-sibling::td"))
             row = col.getparent()
-            for tr in self.xpath(row, "./following-sibling::tr")[:span-1]:
+            for tr in self.xpath(row, "./following-sibling::tr")[:span - 1]:
                 # if not cloned, child will be moved to new parent
                 clone = self.clone(col)
                 # XXX: beware that here we don't use an "adapted" function,
@@ -1038,7 +1038,7 @@ class DOMHTMLSoundtrackParser(DOMParserBase):
                         for sep in ' with ', ' by ', ' from ', ' of ':
                             fdix = l.find(sep)
                             if fdix != -1:
-                                fdix = fdix+len(sep)
+                                fdix = fdix + len(sep)
                                 kind = l[:fdix].rstrip().lower()
                                 info = l[fdix:].lstrip()
                                 newData[title][kind] = info

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -716,30 +716,30 @@ class DOMHTMLMovieParser(DOMParserBase):
         if 'number of seasons' in data:
             data['seasons'] = [unicode(i) for i in range(1, data['number of seasons'] + 1)]
             # data['number of seasons'] = seasons[-1] if seasons else len(data['seasons'])
-        if 'original air date' in data:
-            oid = self.re_space.sub(' ', data['original air date']).strip()
-            data['original air date'] = oid
-            aid = self.re_airdate.findall(oid)
-            if aid and len(aid[0]) == 3:
-                date, season, episode = aid[0]
-                date = date.strip()
-                try:
-                    season = int(season)
-                except:
-                    pass
-                try:
-                    episode = int(episode)
-                except:
-                    pass
-                if date and date != '????':
-                    data['original air date'] = date
-                else:
-                    del data['original air date']
-                # Handle also "episode 0".
-                if season or isinstance(season, int):
-                    data['season'] = season
-                if episode or isinstance(season, int):
-                    data['episode'] = episode
+        # if 'original air date' in data:
+        #     oid = self.re_space.sub(' ', data['original air date']).strip()
+        #     data['original air date'] = oid
+        #     aid = self.re_airdate.findall(oid)
+        #     if aid and len(aid[0]) == 3:
+        #         date, season, episode = aid[0]
+        #         date = date.strip()
+        #         try:
+        #             season = int(season)
+        #         except ValueError:
+        #             pass
+        #         try:
+        #             episode = int(episode)
+        #         except ValueError:
+        #             pass
+        #         if date and date != '????':
+        #             data['original air date'] = date
+        #         else:
+        #             del data['original air date']
+        #         # Handle also "episode 0".
+        #         if season or isinstance(season, int):
+        #             data['season'] = season
+        #         if episode or isinstance(season, int):
+        #             data['episode'] = episode
         for k in ('writer', 'director'):
             t_k = 'thin %s' % k
             if t_k not in data:

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -5,7 +5,7 @@ This module provides the classes (and the instances), used to parse the
 IMDb pages on the akas.imdb.com server about a movie.
 E.g., for Brian De Palma's "The Untouchables", the referred
 pages would be:
-    combined details:   http://akas.imdb.com/title/tt0094226/combined
+    combined details:   http://akas.imdb.com/title/tt0094226/reference
     plot summary:       http://akas.imdb.com/title/tt0094226/plotsummary
     ...and so on...
 

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -170,7 +170,10 @@ def analyze_og_title(og_title):
     match = _re_og_title.match(og_title)
     if match:
         data['title'] = match.group(1)
-        data['year'] = int(match.group(3)) if match.group(3) else None
+
+        if match.group(3):
+            data['year'] = int(match.group(3))
+
         kind = match.group(2) or match.group(6)
         if kind is None:
             kind = 'movie'
@@ -191,12 +194,8 @@ def analyze_og_title(og_title):
             elif kind.endswith('series'):
                 data['series years'] = '%(year)d-' % {'year': data['year']}
         # No year separator and series, so assume that it ended the same year
-        elif kind.endswith('series'):
-            data['series years'] = (
-                '%(year)d-%(year)d' % {'year': data['year']}
-                if data['year'] else
-                None
-            )
+        elif kind.endswith('series') and 'year' in data:
+            data['series years'] = '%(year)d-%(year)d' % {'year': data['year']}
 
         if data['kind'] == 'episode' and data['title'][0] == '"':
             quote_end = data['title'].find('"', 1)

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -247,12 +247,13 @@ class DOMHTMLMovieParser(DOMParserBase):
             )
         ),
 
+        # parser for misc sections like 'casting department', 'stunts', ...
         Extractor(
             label='glossarysections',
-            group="//a[@class='glossary']",
+            group="//h4[contains(@class, 'ipl-header__content')]",
             group_key="./@name",
             group_key_normalize=lambda x: x.replace('_', ' '),
-            path="../../../..//tr",
+            path="../../following-sibling::table[1]//tr",
             attrs=Attribute(
                 key=None,
                 multi=True,
@@ -423,7 +424,6 @@ class DOMHTMLMovieParser(DOMParserBase):
                 )
             ]
         ),
-
 
         Extractor(
             label='creator',

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -336,11 +336,6 @@ class DOMHTMLMovieParser(DOMParserBase):
             label='h5sections',
             path="//section[contains(@class, 'listo')]",
             attrs=[
-                # Attribute(
-                #     key="mpaa",
-                #     path=".//td/a[starts-with(text(), 'MPAA')]/../../div/text()",
-                #     postprocess=lambda x: x.strip()
-                # ),
                 # Collects akas not encosed in <i> tags.
                 Attribute(
                     key='other akas',

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -395,11 +395,6 @@ class DOMHTMLMovieParser(DOMParserBase):
                     postprocess=makeSplitter('Certification:', sep='\n')
                 ),
                 Attribute(
-                    key='seasons',
-                    path=".//td[starts-with(text(), 'Seasons')]/..//text()",
-                    postprocess=makeSplitter('Seasons:')
-                ),
-                Attribute(
                     key='original air date',
                     path=".//td[starts-with(text(), 'Original Air Date')]/../div/text()"
                 )
@@ -516,6 +511,16 @@ class DOMHTMLMovieParser(DOMParserBase):
                 key='next episode',
                 path="./@href",
                 postprocess=lambda x: analyze_imdbid(x)
+            )
+        ),
+
+        Extractor(
+            label='number of seasons',
+            path=".//section[@class='titlereference-section-overview']/div/a[1]",
+            attrs=Attribute(
+                key='number of seasons',
+                path="./text()",
+                postprocess=lambda x: int(x)
             )
         ),
 
@@ -702,9 +707,9 @@ class DOMHTMLMovieParser(DOMParserBase):
         if 'runtimes' in data:
             data['runtimes'] = [x.replace(' min', u'')
                                 for x in data['runtimes']]
-        if 'seasons' in data:
-            seasons = [int(s) for s in data['seasons'] if s.isdigit()]
-            data['number of seasons'] = seasons[-1] if seasons else len(data['seasons'])
+        if 'number of seasons' in data:
+            data['seasons'] = [i for i in range(1, data['number of seasons'] + 1)]
+            # data['number of seasons'] = seasons[-1] if seasons else len(data['seasons'])
         if 'original air date' in data:
             oid = self.re_space.sub(' ', data['original air date']).strip()
             data['original air date'] = oid

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -156,6 +156,34 @@ def _toInt(val, replace=()):
         return None
 
 
+_re_og_title = re.compile(r'(.*) \(((.*) )?((\d{4})(-(\d{4}| ))?)\)')
+
+
+def analyze_og_title(og_title):
+    data = {}
+    match = _re_og_title.match(og_title)
+    if match:
+        data['title'] = match.group(1)
+        data['year'] = int(match.group(5))
+        kind = match.group(3)
+        if kind is None:
+            kind = 'Movie'
+        else:
+            if kind == 'TV Episode':
+                kind = 'Episode'
+            elif kind == 'TV Mini-Series':
+                kind = 'TV Mini Series'
+            elif kind == 'Video':
+                kind = 'Video Movie'
+        data['kind'] = kind.lower()
+        years = match.group(6)
+        if years is not None:
+            data['series years'] = match.group(4).strip()
+        elif kind.endswith('Series'):
+            data['series years'] = '%(year)d-%(year)d' % {'year': data['year']}
+    return data
+
+
 class DOMHTMLMovieParser(DOMParserBase):
     """Parser for the "combined details" (and if instance.mdparse is
     True also for the "main details") page of a given movie.
@@ -176,7 +204,7 @@ class DOMHTMLMovieParser(DOMParserBase):
             attrs=Attribute(
                 key='title',
                 path="@content",
-                postprocess=analyze_title
+                postprocess=analyze_og_title
             )
         ),
 

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -220,7 +220,7 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='genres',
-            path="//div[@class='info']//a[starts-with(@href, '/Sections/Genres')]",
+            path="//td[starts-with(text(), 'Genre')]/..//li/a",
             attrs=Attribute(
                 key="genres",
                 multi=True,

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -243,7 +243,7 @@ class DOMHTMLMovieParser(DOMParserBase):
             attrs=[
                 Attribute(
                     key="plot summary",
-                    path=".//td[starts-with(text(), 'Plot:')]/../div/text()",
+                    path=".//td[starts-with(text(), 'Plot')]/..//p/text()",
                     postprocess=lambda x: x.strip().rstrip('|').rstrip()
                 ),
                 Attribute(

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -219,6 +219,15 @@ class DOMHTMLMovieParser(DOMParserBase):
         ),
 
         Extractor(
+            label='myrating',
+            path="//span[@id='voteuser']",
+            attrs=Attribute(
+                key='myrating',
+                path=".//text()"
+            )
+        ),
+
+        Extractor(
             label='genres',
             path="//td[starts-with(text(), 'Genre')]/..//li/a",
             attrs=Attribute(
@@ -229,17 +238,8 @@ class DOMHTMLMovieParser(DOMParserBase):
         ),
 
         Extractor(
-            label='myrating',
-            path="//span[@id='voteuser']",
-            attrs=Attribute(
-                key='myrating',
-                path=".//text()"
-            )
-        ),
-
-        Extractor(
             label='color info',
-            path=".//td[starts-with(text(), 'Color')]/..//li/a",
+            path="//td[starts-with(text(), 'Color')]/..//li/a",
             attrs=Attribute(
                 key='color info',
                 path="./text()",
@@ -250,7 +250,7 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='sound mix',
-            path=".//td[starts-with(text(), 'Sound Mix')]/..//li/a",
+            path="//td[starts-with(text(), 'Sound Mix')]/..//li/a",
             attrs=Attribute(
                 key='sound mix',
                 path="./text()",

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -258,7 +258,8 @@ class DOMHTMLMovieParser(DOMParserBase):
                 ),
                 Attribute(
                     key="countries",
-                    path="./h5[starts-with(text(), 'Countr')]/../div[@class='info-content']//text()",
+                    path="./h5[starts-with(text(), 'Countr')]/.."
+                         "/div[@class='info-content']//text()",
                     postprocess=makeSplitter('|')
                 ),
                 Attribute(
@@ -273,7 +274,8 @@ class DOMHTMLMovieParser(DOMParserBase):
                 ),
                 Attribute(
                     key='sound mix',
-                    path="./h5[starts-with(text(), 'Sound Mix')]/../div[@class='info-content']//text()",
+                    path="./h5[starts-with(text(), 'Sound Mix')]/.."
+                         "/div[@class='info-content']//text()",
                     postprocess=makeSplitter()
                 ),
                 # Collects akas not encosed in <i> tags.
@@ -316,7 +318,8 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='language codes',
-            path="//h5[starts-with(text(), 'Language')]/..//a[starts-with(@href, '/language/')]",
+            path="//h5[starts-with(text(), 'Language')]/.."
+                 "//a[starts-with(@href, '/language/')]",
             attrs=Attribute(
                 key='language codes',
                 multi=True,
@@ -576,7 +579,8 @@ class DOMHTMLMovieParser(DOMParserBase):
             proLink.drop_tree()
         # Remove some 'more' links (keep others, like the one around
         # the number of votes).
-        for tn15more in self.xpath(dom, "//a[@class='tn15more'][starts-with(@href, '/title/')]"):
+        for tn15more in self.xpath(dom,
+                                   "//a[@class='tn15more'][starts-with(@href, '/title/')]"):
             tn15more.drop_tree()
         return dom
 
@@ -785,7 +789,8 @@ class DOMHTMLAwardsParser(DOMParserBase):
                     'award': "../td[3]/text()",
                     'category': "./text()[1]",
                     # FIXME: takes only the first co-recipient
-                    'with': "./small[starts-with(text(), 'Shared with:')]/following-sibling::a[1]/text()",
+                    'with': "./small[starts-with(text(), 'Shared with:')]/"
+                            "following-sibling::a[1]/text()",
                     'notes': "./small[last()]//text()",
                     'anchor': ".//text()"
                 },
@@ -797,7 +802,8 @@ class DOMHTMLAwardsParser(DOMParserBase):
             label='recipients',
             group="//table//big",
             group_key="./a",
-            path="./ancestor::tr[1]/following-sibling::tr/td[last()]/small[1]/preceding-sibling::a",
+            path="./ancestor::tr[1]/following-sibling::tr"
+                 "/td[last()]/small[1]/preceding-sibling::a",
             attrs=Attribute(
                 key=None,
                 multi=True,

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -393,10 +393,6 @@ class DOMHTMLMovieParser(DOMParserBase):
                     key='certificates',
                     path=".//td[starts-with(text(), 'Certificat')]/..//text()",
                     postprocess=makeSplitter('Certification:', sep='\n')
-                ),
-                Attribute(
-                    key='original air date',
-                    path=".//td[starts-with(text(), 'Original Air Date')]/../div/text()"
                 )
             ]
         ),
@@ -458,6 +454,15 @@ class DOMHTMLMovieParser(DOMParserBase):
             path="//li[@class='ipl-inline-list__item']//a[starts-with(@href, '/chart/')]",
             attrs=Attribute(
                 key='top/bottom rank',
+                path="./text()"
+            )
+        ),
+
+        Extractor(
+            label='original air date',
+            path="//span[@imdbpy='airdate']",
+            attrs=Attribute(
+                key='original air date',
                 path="./text()"
             )
         ),
@@ -638,6 +643,7 @@ class DOMHTMLMovieParser(DOMParserBase):
     ]
 
     preprocessors = [
+        ('/releaseinfo">', '"><span imdbpy="airdate">'),
         (re.compile(r'(<b class="blackcatheader">.+?</b>)', re.I), r'</div><div>\1'),
         ('<small>Full cast and crew for<br>', ''),
         ('<td> </td>', '<td>...</td>'),

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -249,6 +249,16 @@ class DOMHTMLMovieParser(DOMParserBase):
         ),
 
         Extractor(
+            label='aspect ratio',
+            path="//td[starts-with(text(), 'Aspect')]/..",
+            attrs=Attribute(
+                key='aspect ratio',
+                path=".//li/text()",
+                postprocess=lambda x: x.strip()
+            )
+        ),
+
+        Extractor(
             label='sound mix',
             path="//td[starts-with(text(), 'Sound Mix')]/..//li/a",
             attrs=Attribute(
@@ -267,11 +277,6 @@ class DOMHTMLMovieParser(DOMParserBase):
                     key="plot summary",
                     path=".//td[starts-with(text(), 'Plot')]/..//p/text()",
                     postprocess=lambda x: x.strip().rstrip('|').rstrip()
-                ),
-                Attribute(
-                    key="aspect ratio",
-                    path=".//td[starts-with(text(), 'Aspect')]/..//li/text()",
-                    postprocess=lambda x: x.strip()
                 ),
                 # Attribute(
                 #     key="mpaa",

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -238,6 +238,17 @@ class DOMHTMLMovieParser(DOMParserBase):
         ),
 
         Extractor(
+            label='color info',
+            path=".//td[starts-with(text(), 'Color')]/..//li/a",
+            attrs=Attribute(
+                key='color info',
+                path="./text()",
+                multi=True,
+                postprocess=lambda x: x.replace(' (', '::(')
+            )
+        ),
+
+        Extractor(
             label='sound mix',
             path=".//td[starts-with(text(), 'Sound Mix')]/..//li/a",
             attrs=Attribute(
@@ -277,12 +288,6 @@ class DOMHTMLMovieParser(DOMParserBase):
                     key="language",
                     path=".//td[starts-with(text(), 'Language')]/..//text()",
                     postprocess=makeSplitter('Language:')
-                ),
-                Attribute(
-                    key='color info',
-                    path=".//td[starts-with(text(), 'Color')]/..//li/a/text()",
-                    multi=True,
-                    postprocess=lambda x: x.replace(' (', '::(')
                 ),
                 # Collects akas not encosed in <i> tags.
                 Attribute(

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -228,6 +228,16 @@ class DOMHTMLMovieParser(DOMParserBase):
         ),
 
         Extractor(
+            label='plot summary',
+            path=".//td[starts-with(text(), 'Plot')]/..",
+            attrs=Attribute(
+                key='plot summary',
+                path='./p//text()',
+                postprocess=lambda x: x.strip().rstrip('|').rstrip()
+            )
+        ),
+
+        Extractor(
             label='genres',
             path="//td[starts-with(text(), 'Genre')]/..//li/a",
             attrs=Attribute(

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -248,7 +248,7 @@ class DOMHTMLMovieParser(DOMParserBase):
                 ),
                 Attribute(
                     key="aspect ratio",
-                    path=".//td[starts-with(text(), 'Aspect')]/../div/text()",
+                    path=".//td[starts-with(text(), 'Aspect')]/..//li/text()",
                     postprocess=lambda x: x.strip()
                 ),
                 Attribute(

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -29,6 +29,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
 
+import functools
 import re
 import urllib
 
@@ -199,6 +200,24 @@ def analyze_og_title(og_title):
             data['title'] = data['title'][quote_end + 1:].strip()
 
     return data
+
+
+def analyze_certificates(certificates):
+    def reducer(acc, el):
+        cert_re = re.compile(r'^(.+):(.+)$', re.UNICODE)
+
+        if cert_re.match(el):
+            acc.append(el)
+        elif acc:
+            acc[-1] = u'{}::{}'.format(
+                acc[-1],
+                el,
+            )
+
+        return acc
+
+    certificates = [el.strip() for el in certificates.split('\n') if el.strip()]
+    return functools.reduce(reducer, certificates, [])
 
 
 class DOMHTMLMovieParser(DOMParserBase):
@@ -378,6 +397,16 @@ class DOMHTMLMovieParser(DOMParserBase):
         ),
 
         Extractor(
+            label='certificates',
+            path=".//td[starts-with(text(), 'Certificat')]/..",
+            attrs=Attribute(
+                key='certificates',
+                path=".//text()",
+                postprocess=analyze_certificates
+            )
+        ),
+
+        Extractor(
             label='h5sections',
             path="//section[contains(@class, 'listo')]",
             attrs=[
@@ -388,11 +417,6 @@ class DOMHTMLMovieParser(DOMParserBase):
                     postprocess=makeSplitter(
                         sep='::', origNotesSep='" - ', newNotesSep='::', strip='"'
                     )
-                ),
-                Attribute(
-                    key='certificates',
-                    path=".//td[starts-with(text(), 'Certificat')]/..//text()",
-                    postprocess=makeSplitter('Certification:', sep='\n')
                 )
             ]
         ),

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -160,7 +160,7 @@ def _toInt(val, replace=()):
 
 
 _re_og_title = re.compile(
-    ur'(.*) \((?:(.+)(?= ))? ?(\d{4})(?:(–)(\d{4}| ))?\)',
+    ur'(.*) \((?:(?:(.+)(?= ))? ?(\d{4})(?:(–)(\d{4}| ))?|(.+))\)',
     re.UNICODE
 )
 
@@ -170,8 +170,8 @@ def analyze_og_title(og_title):
     match = _re_og_title.match(og_title)
     if match:
         data['title'] = match.group(1)
-        data['year'] = int(match.group(3))
-        kind = match.group(2)
+        data['year'] = int(match.group(3)) if match.group(3) else None
+        kind = match.group(2) or match.group(6)
         if kind is None:
             kind = 'movie'
         else:
@@ -192,7 +192,11 @@ def analyze_og_title(og_title):
                 data['series years'] = '%(year)d-' % {'year': data['year']}
         # No year separator and series, so assume that it ended the same year
         elif kind.endswith('series'):
-            data['series years'] = '%(year)d-%(year)d' % {'year': data['year']}
+            data['series years'] = (
+                '%(year)d-%(year)d' % {'year': data['year']}
+                if data['year'] else
+                None
+            )
 
         if data['kind'] == 'episode' and data['title'][0] == '"':
             quote_end = data['title'].find('"', 1)

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -248,6 +248,27 @@ class DOMHTMLMovieParser(DOMParserBase):
         ),
 
         Extractor(
+            label='countries',
+            path="//td[starts-with(text(), 'Countr')]/..//li/a",
+            attrs=Attribute(
+                key='countries',
+                path="./text()",
+                multi=True
+            )
+        ),
+
+        Extractor(
+            label='country codes',
+            path="//td[starts-with(text(), 'Countr')]/..//li/a",
+            attrs=Attribute(
+                key='country codes',
+                path="./@href",
+                multi=True,
+                postprocess=lambda x: x.split('/')[2].strip().lower()
+            )
+        ),
+
+        Extractor(
             label='color info',
             path="//td[starts-with(text(), 'Color')]/..//li/a",
             attrs=Attribute(
@@ -288,12 +309,6 @@ class DOMHTMLMovieParser(DOMParserBase):
                 #     path=".//td/a[starts-with(text(), 'MPAA')]/../../div/text()",
                 #     postprocess=lambda x: x.strip()
                 # ),
-                Attribute(
-                    key="countries",
-                    path=".//td[starts-with(text(), 'Countr')]/.."
-                         "/div[@class='info-content']//text()",
-                    postprocess=makeSplitter('|')
-                ),
                 Attribute(
                     key="language",
                     path=".//td[starts-with(text(), 'Language')]/..//text()",
@@ -343,17 +358,6 @@ class DOMHTMLMovieParser(DOMParserBase):
                  "//a[starts-with(@href, '/language/')]",
             attrs=Attribute(
                 key='language codes',
-                multi=True,
-                path="./@href",
-                postprocess=lambda x: x.split('/')[2].strip()
-            )
-        ),
-
-        Extractor(
-            label='country codes',
-            path="//td[starts-with(text(), 'Country')]/..//a[starts-with(@href, '/country/')]",
-            attrs=Attribute(
-                key='country codes',
                 multi=True,
                 path="./@href",
                 postprocess=lambda x: x.split('/')[2].strip()

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -460,7 +460,7 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='top 250/bottom 100',
-            path="//div[@class='starbar-special']/a[starts-with(@href, '/chart/')]",
+            path="//li[@class='ipl-inline-list__item']//a[starts-with(@href, '/chart/')]",
             attrs=Attribute(
                 key='top/bottom rank',
                 path="./text()"
@@ -740,10 +740,10 @@ class DOMHTMLMovieParser(DOMParserBase):
             tbVal = data['top/bottom rank'].lower()
             if tbVal.startswith('top'):
                 tbKey = 'top 250 rank'
-                tbVal = _toInt(tbVal, [('top 250: #', '')])
+                tbVal = _toInt(tbVal, [('top rated movies: #', '')])
             else:
                 tbKey = 'bottom 100 rank'
-                tbVal = _toInt(tbVal, [('bottom 100: #', '')])
+                tbVal = _toInt(tbVal, [('bottom rated movies: #', '')])
             if tbVal:
                 data[tbKey] = tbVal
             del data['top/bottom rank']

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -485,11 +485,11 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='number of episodes',
-            path="//a[@title='Full Episode List']",
+            path="//a[starts-with(text(), 'All Episodes')]",
             attrs=Attribute(
                 key='number of episodes',
                 path="./text()",
-                postprocess=lambda x: _toInt(x, [(' Episodes', '')])
+                postprocess=lambda x: int(x.replace('All Episodes', '').strip()[1:-1])
             )
         ),
 

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -269,9 +269,9 @@ class DOMHTMLMovieParser(DOMParserBase):
                 ),
                 Attribute(
                     key='color info',
-                    path=".//td[starts-with(text(), 'Color')]/.."
-                         "/div[@class='info-content']//text()",
-                    postprocess=makeSplitter('|')
+                    path=".//td[starts-with(text(), 'Color')]/..//li/a/text()",
+                    multi=True,
+                    postprocess=lambda x: x.replace(' (', '::(')
                 ),
                 Attribute(
                     key='sound mix',

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -172,7 +172,7 @@ class DOMHTMLMovieParser(DOMParserBase):
     extractors = [
         Extractor(
             label='title',
-            path="//h1",
+            path="//h3[@itemprop='name']",
             attrs=Attribute(
                 key='title',
                 path=".//text()",
@@ -239,86 +239,87 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='h5sections',
-            path="//div[@class='info']/h5/..",
+            path="//section[contains(@class, 'listo')]",
             attrs=[
                 Attribute(
                     key="plot summary",
-                    path="./h5[starts-with(text(), 'Plot:')]/../div/text()",
+                    path=".//td[starts-with(text(), 'Plot:')]/../div/text()",
                     postprocess=lambda x: x.strip().rstrip('|').rstrip()
                 ),
                 Attribute(
                     key="aspect ratio",
-                    path="./h5[starts-with(text(), 'Aspect')]/../div/text()",
+                    path=".//td[starts-with(text(), 'Aspect')]/../div/text()",
                     postprocess=lambda x: x.strip()
                 ),
                 Attribute(
                     key="mpaa",
-                    path="./h5/a[starts-with(text(), 'MPAA')]/../../div/text()",
+                    path=".//td/a[starts-with(text(), 'MPAA')]/../../div/text()",
                     postprocess=lambda x: x.strip()
                 ),
                 Attribute(
                     key="countries",
-                    path="./h5[starts-with(text(), 'Countr')]/.."
+                    path=".//td[starts-with(text(), 'Countr')]/.."
                          "/div[@class='info-content']//text()",
                     postprocess=makeSplitter('|')
                 ),
                 Attribute(
                     key="language",
-                    path="./h5[starts-with(text(), 'Language')]/..//text()",
+                    path=".//td[starts-with(text(), 'Language')]/..//text()",
                     postprocess=makeSplitter('Language:')
                 ),
                 Attribute(
                     key='color info',
-                    path="./h5[starts-with(text(), 'Color')]/..//text()",
+                    path=".//td[starts-with(text(), 'Color')]/.."
+                         "/div[@class='info-content']//text()",
                     postprocess=makeSplitter('|')
                 ),
                 Attribute(
                     key='sound mix',
-                    path="./h5[starts-with(text(), 'Sound Mix')]/.."
+                    path=".//td[starts-with(text(), 'Sound Mix')]/.."
                          "/div[@class='info-content']//text()",
                     postprocess=makeSplitter()
                 ),
                 # Collects akas not encosed in <i> tags.
                 Attribute(
                     key='other akas',
-                    path="./h5[starts-with(text(), 'Also Known As')]/../div//text()",
+                    path=".//td[starts-with(text(), 'Also Known As')]/..//ul//text()",
                     postprocess=makeSplitter(
                         sep='::', origNotesSep='" - ', newNotesSep='::', strip='"'
                     )
                 ),
                 Attribute(
                     key='runtimes',
-                    path="./h5[starts-with(text(), 'Runtime')]/../div/text()",
+                    path=".//td[starts-with(text(), 'Runtime')]/..//ul//text()",
                     postprocess=makeSplitter()
                 ),
                 Attribute(
                     key='certificates',
-                    path="./h5[starts-with(text(), 'Certificat')]/..//text()",
-                    postprocess=makeSplitter('Certification:')
+                    path=".//td[starts-with(text(), 'Certificat')]/..//text()",
+                    postprocess=makeSplitter('Certification:', sep='\n')
                 ),
                 Attribute(
                     key='seasons',
-                    path="./h5[starts-with(text(), 'Seasons')]/..//text()",
+                    path=".//td[starts-with(text(), 'Seasons')]/..//text()",
                     postprocess=makeSplitter('Seasons:')
                 ),
                 Attribute(
                     key='original air date',
-                    path="./h5[starts-with(text(), 'Original Air Date')]/../div/text()"
+                    path=".//td[starts-with(text(), 'Original Air Date')]/../div/text()"
                 ),
                 Attribute(
                     key='tv series link',
-                    path="./h5[starts-with(text(), 'TV Series')]/..//a/@href"
+                    path=".//td[starts-with(text(), 'TV Series')]/..//a/@href"
                 ),
                 Attribute(
                     key='tv series title',
-                    path="./h5[starts-with(text(), 'TV Series')]/..//a/text()"
+                    path=".//td[starts-with(text(), 'TV Series')]/..//a/text()"
                 )
             ]
         ),
 
         Extractor(
             label='language codes',
-            path="//h5[starts-with(text(), 'Language')]/.."
+            path="//td[starts-with(text(), 'Language')]/.."
                  "//a[starts-with(@href, '/language/')]",
             attrs=Attribute(
                 key='language codes',
@@ -330,7 +331,7 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='country codes',
-            path="//h5[starts-with(text(), 'Country')]/..//a[starts-with(@href, '/country/')]",
+            path="//td[starts-with(text(), 'Country')]/..//a[starts-with(@href, '/country/')]",
             attrs=Attribute(
                 key='country codes',
                 multi=True,
@@ -341,7 +342,7 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='creator',
-            path="//h5[starts-with(text(), 'Creator')]/..//a",
+            path="//td[starts-with(text(), 'Creator')]/..//a",
             attrs=Attribute(
                 key='creator',
                 multi=True,
@@ -358,7 +359,7 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='thin writer',
-            path="//h5[starts-with(text(), 'Writer')]/..//a",
+            path="//td[starts-with(text(), 'Writer')]/..//a",
             attrs=Attribute(
                 key='thin writer',
                 multi=True,
@@ -375,7 +376,7 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='thin director',
-            path="//h5[starts-with(text(), 'Director')]/..//a",
+            path="//td[starts-with(text(), 'Director')]/..//a",
             attrs=Attribute(
                 key='thin director',
                 multi=True,
@@ -469,7 +470,7 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='production notes/status',
-            path="//h5[starts-with(text(), 'Status:')]/..//div[@class='info-content']",
+            path="//td[starts-with(text(), 'Status:')]/..//div[@class='info-content']",
             attrs=Attribute(
                 key='production status',
                 path=".//text()",
@@ -479,7 +480,7 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='production notes/status updated',
-            path="//h5[starts-with(text(), 'Status Updated:')]/..//div[@class='info-content']",
+            path="//td[starts-with(text(), 'Status Updated:')]/..//div[@class='info-content']",
             attrs=Attribute(
                 key='production status updated',
                 path=".//text()",
@@ -489,7 +490,7 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='production notes/comments',
-            path="//h5[starts-with(text(), 'Comments:')]/..//div[@class='info-content']",
+            path="//td[starts-with(text(), 'Comments:')]/..//div[@class='info-content']",
             attrs=Attribute(
                 key='production comments',
                 path=".//text()",
@@ -499,7 +500,7 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='production notes/note',
-            path="//h5[starts-with(text(), 'Note:')]/..//div[@class='info-content']",
+            path="//td[starts-with(text(), 'Note:')]/..//div[@class='info-content']",
             attrs=Attribute(
                 key='production note',
                 path=".//text()",
@@ -529,28 +530,28 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='rating',
-            path="//div[@class='starbar-meta']/b",
+            path="(//span[@class='ipl-rating-star__rating'])[1]",
             attrs=Attribute(
                 key='rating',
-                path=".//text()"
+                path="./text()"
             )
         ),
 
         Extractor(
             label='votes',
-            path="//div[@class='starbar-meta']/a[@href]",
+            path="//span[@class='ipl-rating-star__total-votes'][1]",
             attrs=Attribute(
                 key='votes',
-                path=".//text()"
+                path="./text()"
             )
         ),
 
         Extractor(
             label='cover url',
-            path="//a[@name='poster']",
+            path="//img[@alt='Poster']",
             attrs=Attribute(
                 key='cover url',
-                path="./img/@src"
+                path="@src"
             )
         )
     ]
@@ -687,7 +688,7 @@ class DOMHTMLMovieParser(DOMParserBase):
                 pass
         if 'votes' in data:
             try:
-                votes = data['votes'].replace(',', '').replace('votes', '')
+                votes = data['votes'].replace('(', '').replace(')', '').replace(',', '').replace('votes', '')
                 data['votes'] = int(votes)
             except (TypeError, ValueError):
                 pass

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -229,10 +229,10 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='plot summary',
-            path=".//td[starts-with(text(), 'Plot')]/..",
+            path=".//td[starts-with(text(), 'Plot')]/..//p",
             attrs=Attribute(
                 key='plot summary',
-                path='./p//text()',
+                path='./text()',
                 postprocess=lambda x: x.strip().rstrip('|').rstrip()
             )
         ),
@@ -283,11 +283,6 @@ class DOMHTMLMovieParser(DOMParserBase):
             label='h5sections',
             path="//section[contains(@class, 'listo')]",
             attrs=[
-                Attribute(
-                    key="plot summary",
-                    path=".//td[starts-with(text(), 'Plot')]/..//p/text()",
-                    postprocess=lambda x: x.strip().rstrip('|').rstrip()
-                ),
                 # Attribute(
                 #     key="mpaa",
                 #     path=".//td/a[starts-with(text(), 'MPAA')]/../../div/text()",

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -238,6 +238,17 @@ class DOMHTMLMovieParser(DOMParserBase):
         ),
 
         Extractor(
+            label='sound mix',
+            path=".//td[starts-with(text(), 'Sound Mix')]/..//li/a",
+            attrs=Attribute(
+                key='sound mix',
+                path="./text()",
+                multi=True,
+                postprocess=lambda x: x.replace(' (', '::(')
+            )
+        ),
+
+        Extractor(
             label='h5sections',
             path="//section[contains(@class, 'listo')]",
             attrs=[
@@ -272,12 +283,6 @@ class DOMHTMLMovieParser(DOMParserBase):
                     path=".//td[starts-with(text(), 'Color')]/..//li/a/text()",
                     multi=True,
                     postprocess=lambda x: x.replace(' (', '::(')
-                ),
-                Attribute(
-                    key='sound mix',
-                    path=".//td[starts-with(text(), 'Sound Mix')]/.."
-                         "/div[@class='info-content']//text()",
-                    postprocess=makeSplitter()
                 ),
                 # Collects akas not encosed in <i> tags.
                 Attribute(

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -412,7 +412,7 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='thin writer',
-            path="//td[starts-with(text(), 'Writer')]/..//a",
+            path="//div[starts-with(normalize-space(text()), 'Writer')]/ul/li[1]/a",
             attrs=Attribute(
                 key='thin writer',
                 multi=True,
@@ -429,13 +429,13 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='thin director',
-            path="//td[starts-with(text(), 'Director')]/..//a",
+            path="//div[starts-with(normalize-space(text()), 'Director')]/ul/li[1]/a",
             attrs=Attribute(
                 key='thin director',
                 multi=True,
                 path={
                     'name': "./text()",
-                    'link': "@href"
+                    'link': "./@href"
                 },
                 postprocess=lambda x: build_person(
                     x.get('name') or u'',

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -478,6 +478,16 @@ class DOMHTMLMovieParser(DOMParserBase):
         ),
 
         Extractor(
+            label='season/episode',
+            path="//div[@class='titlereference-overview-season-episode-section']/ul",
+            attrs=Attribute(
+                key='season/episode',
+                path=".//text()",
+                postprocess=lambda x: x.strip()
+            )
+        ),
+
+        Extractor(
             label='number of episodes',
             path="//a[starts-with(text(), 'All Episodes')]",
             attrs=Attribute(
@@ -716,6 +726,11 @@ class DOMHTMLMovieParser(DOMParserBase):
         if 'number of seasons' in data:
             data['seasons'] = [unicode(i) for i in range(1, data['number of seasons'] + 1)]
             # data['number of seasons'] = seasons[-1] if seasons else len(data['seasons'])
+        if 'season/episode' in data:
+            tokens = data['season/episode'].split('Episode')
+            data['season'] = int(tokens[0].split('Season')[1])
+            data['episode'] = int(tokens[1])
+            del data['season/episode']
         # if 'original air date' in data:
         #     oid = self.re_space.sub(' ', data['original air date']).strip()
         #     data['original air date'] = oid

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -31,63 +31,63 @@ import re
 import urllib
 
 from imdb import imdbURL_base
-from imdb.Person import Person
-from imdb.Movie import Movie
 from imdb.Company import Company
-from imdb.utils import analyze_title, _Container
-from utils import build_person, DOMParserBase, Attribute, Extractor, \
-                    analyze_imdbid
+from imdb.Movie import Movie
+from imdb.Person import Person
+from imdb.utils import _Container, analyze_title
+
+from .utils import Attribute, DOMParserBase, Extractor, analyze_imdbid, build_person
 
 
 # Dictionary used to convert some section's names.
 _SECT_CONV = {
-        'directed': 'director',
-        'directed by': 'director',
-        'directors': 'director',
-        'editors': 'editor',
-        'writing credits': 'writer',
-        'writers': 'writer',
-        'produced': 'producer',
-        'cinematography': 'cinematographer',
-        'film editing': 'editor',
-        'casting': 'casting director',
-        'costume design': 'costume designer',
-        'makeup department': 'make up',
-        'production management': 'production manager',
-        'second unit director or assistant director': 'assistant director',
-        'costume and wardrobe department': 'costume department',
-        'sound department': 'sound crew',
-        'stunts':   'stunt performer',
-        'other crew': 'miscellaneous crew',
-        'also known as': 'akas',
-        'country':  'countries',
-        'runtime':  'runtimes',
-        'language': 'languages',
-        'certification':    'certificates',
-        'genre': 'genres',
-        'created': 'creator',
-        'creators': 'creator',
-        'color': 'color info',
-        'plot': 'plot outline',
-        'art directors': 'art direction',
-        'assistant directors': 'assistant director',
-        'set decorators': 'set decoration',
-        'visual effects department': 'visual effects',
-        'miscellaneous': 'miscellaneous crew',
-        'make up department': 'make up',
-        'plot summary': 'plot outline',
-        'cinematographers': 'cinematographer',
-        'camera department': 'camera and electrical department',
-        'costume designers': 'costume designer',
-        'production designers': 'production design',
-        'production managers': 'production manager',
-        'music original': 'original music',
-        'casting directors': 'casting director',
-        'other companies': 'miscellaneous companies',
-        'producers': 'producer',
-        'special effects by': 'special effects department',
-        'special effects': 'special effects companies'
-        }
+    'directed': 'director',
+    'directed by': 'director',
+    'directors': 'director',
+    'editors': 'editor',
+    'writing credits': 'writer',
+    'writers': 'writer',
+    'produced': 'producer',
+    'cinematography': 'cinematographer',
+    'film editing': 'editor',
+    'casting': 'casting director',
+    'costume design': 'costume designer',
+    'makeup department': 'make up',
+    'production management': 'production manager',
+    'second unit director or assistant director': 'assistant director',
+    'costume and wardrobe department': 'costume department',
+    'sound department': 'sound crew',
+    'stunts':   'stunt performer',
+    'other crew': 'miscellaneous crew',
+    'also known as': 'akas',
+    'country':  'countries',
+    'runtime':  'runtimes',
+    'language': 'languages',
+    'certification':    'certificates',
+    'genre': 'genres',
+    'created': 'creator',
+    'creators': 'creator',
+    'color': 'color info',
+    'plot': 'plot outline',
+    'art directors': 'art direction',
+    'assistant directors': 'assistant director',
+    'set decorators': 'set decoration',
+    'visual effects department': 'visual effects',
+    'miscellaneous': 'miscellaneous crew',
+    'make up department': 'make up',
+    'plot summary': 'plot outline',
+    'cinematographers': 'cinematographer',
+    'camera department': 'camera and electrical department',
+    'costume designers': 'costume designer',
+    'production designers': 'production design',
+    'production managers': 'production manager',
+    'music original': 'original music',
+    'casting directors': 'casting director',
+    'other companies': 'miscellaneous companies',
+    'producers': 'producer',
+    'special effects by': 'special effects department',
+    'special effects': 'special effects companies'
+}
 
 
 def _manageRoles(mo):
@@ -106,28 +106,33 @@ def _manageRoles(mo):
             roleID = u'/'
         else:
             roleID += u'/'
-        newRoles.append(u'<div class="_imdbpyrole" roleid="%s">%s</div>' % \
-                (roleID, role.strip()))
+        newRoles.append(u'<div class="_imdbpyrole" roleid="%s">%s</div>' % (
+            roleID, role.strip()
+        ))
     return firstHalf + u' / '.join(newRoles) + mo.group(3)
 
 
-_reRolesMovie = re.compile(r'(<td class="char">)(.*?)(</td>)',
-                            re.I | re.M | re.S)
+_reRolesMovie = re.compile(r'(<td class="char">)(.*?)(</td>)', re.I | re.M | re.S)
+
 
 def _replaceBR(mo):
     """Replaces <br> tags with '::' (useful for some akas)"""
     txt = mo.group(0)
     return txt.replace('<br>', '::')
 
+
 _reAkas = re.compile(r'<h5>also known as:</h5>.*?</div>', re.I | re.M | re.S)
 
+
 def makeSplitter(lstrip=None, sep='|', comments=True,
-                origNotesSep=' (', newNotesSep='::(', strip=None):
+                 origNotesSep=' (', newNotesSep='::(', strip=None):
     """Return a splitter function suitable for a given set of data."""
     def splitter(x):
-        if not x: return x
+        if not x:
+            return x
         x = x.strip()
-        if not x: return x
+        if not x:
+            return x
         if lstrip is not None:
             x = x.lstrip(lstrip).lstrip()
         lx = x.split(sep)
@@ -164,276 +169,404 @@ class DOMHTMLMovieParser(DOMParserBase):
     """
     _containsObjects = True
 
-    extractors = [Extractor(label='title',
-                            path="//h1",
-                            attrs=Attribute(key='title',
-                                        path=".//text()",
-                                        postprocess=analyze_title)),
+    extractors = [
+        Extractor(
+            label='title',
+            path="//h1",
+            attrs=Attribute(
+                key='title',
+                path=".//text()",
+                postprocess=analyze_title
+            )
+        ),
 
-                Extractor(label='glossarysections',
-                        group="//a[@class='glossary']",
-                        group_key="./@name",
-                        group_key_normalize=lambda x: x.replace('_', ' '),
-                        path="../../../..//tr",
-                        attrs=Attribute(key=None,
-                            multi=True,
-                            path={'person': ".//text()",
-                                    'link': "./td[1]/a[@href]/@href"},
-                            postprocess=lambda x: \
-                                    build_person(x.get('person') or u'',
-                                        personID=analyze_imdbid(x.get('link')))
-                                )),
+        Extractor(
+            label='glossarysections',
+            group="//a[@class='glossary']",
+            group_key="./@name",
+            group_key_normalize=lambda x: x.replace('_', ' '),
+            path="../../../..//tr",
+            attrs=Attribute(
+                key=None,
+                multi=True,
+                path={
+                    'person': ".//text()",
+                    'link': "./td[1]/a[@href]/@href"
+                },
+                postprocess=lambda x: build_person(
+                    x.get('person') or u'',
+                    personID=analyze_imdbid(x.get('link'))
+                )
+            )
+        ),
 
-                Extractor(label='cast',
-                        path="//table[@class='cast']//tr",
-                        attrs=Attribute(key="cast",
-                            multi=True,
-                            path={'person': ".//text()",
-                                'link': "td[2]/a/@href",
-                                'roleID': \
-                                    "td[4]/div[@class='_imdbpyrole']/@roleid"},
-                            postprocess=lambda x: \
-                                    build_person(x.get('person') or u'',
-                                    personID=analyze_imdbid(x.get('link')),
-                                    roleID=(x.get('roleID') or u'').split('/'))
-                                )),
+        Extractor(
+            label='cast',
+            path="//table[@class='cast']//tr",
+            attrs=Attribute(
+                key="cast",
+                multi=True,
+                path={
+                    'person': ".//text()",
+                    'link': "td[2]/a/@href",
+                    'roleID': "td[4]/div[@class='_imdbpyrole']/@roleid"
+                },
+                postprocess=lambda x: build_person(
+                    x.get('person') or u'',
+                    personID=analyze_imdbid(x.get('link')),
+                    roleID=(x.get('roleID') or u'').split('/'))
+            )
+        ),
 
-                Extractor(label='genres',
-                        path="//div[@class='info']//a[starts-with(@href," \
-                                " '/Sections/Genres')]",
-                        attrs=Attribute(key="genres",
-                            multi=True,
-                            path="./text()")),
+        Extractor(
+            label='genres',
+            path="//div[@class='info']//a[starts-with(@href, '/Sections/Genres')]",
+            attrs=Attribute(
+                key="genres",
+                multi=True,
+                path="./text()"
+            )
+        ),
 
-                Extractor(label='myrating',
-                        path="//span[@id='voteuser']",
-                        attrs=Attribute(key='myrating',
-                                        path=".//text()")),
+        Extractor(
+            label='myrating',
+            path="//span[@id='voteuser']",
+            attrs=Attribute(
+                key='myrating',
+                path=".//text()"
+            )
+        ),
 
-                Extractor(label='h5sections',
-                        path="//div[@class='info']/h5/..",
-                        attrs=[
-                            Attribute(key="plot summary",
-                                path="./h5[starts-with(text(), " \
-                                        "'Plot:')]/../div/text()",
-                                postprocess=lambda x: \
-                                        x.strip().rstrip('|').rstrip()),
-                            Attribute(key="aspect ratio",
-                                path="./h5[starts-with(text()," \
-                                        " 'Aspect')]/../div/text()",
-                                postprocess=lambda x: x.strip()),
-                            Attribute(key="mpaa",
-                                path="./h5/a[starts-with(text()," \
-                                        " 'MPAA')]/../../div/text()",
-                                postprocess=lambda x: x.strip()),
-                            Attribute(key="countries",
-                                path="./h5[starts-with(text(), " \
-                            "'Countr')]/../div[@class='info-content']//text()",
-                                postprocess=makeSplitter('|')),
-                            Attribute(key="language",
-                                path="./h5[starts-with(text(), " \
-                                        "'Language')]/..//text()",
-                                    postprocess=makeSplitter('Language:')),
-                            Attribute(key='color info',
-                                path="./h5[starts-with(text(), " \
-                                        "'Color')]/..//text()",
-                                postprocess=makeSplitter('|')),
-                            Attribute(key='sound mix',
-                                path="./h5[starts-with(text(), " \
-                                        "'Sound Mix')]/../div[@class='info-content']//text()",
-                                postprocess=makeSplitter()),
-                            # Collects akas not encosed in <i> tags.
-                            Attribute(key='other akas',
-                                path="./h5[starts-with(text(), " \
-                                        "'Also Known As')]/../div//text()",
-                                postprocess=makeSplitter(sep='::',
-                                                origNotesSep='" - ',
-                                                newNotesSep='::',
-                                                strip='"')),
-                            Attribute(key='runtimes',
-                                path="./h5[starts-with(text(), " \
-                                        "'Runtime')]/../div/text()",
-                                postprocess=makeSplitter()),
-                            Attribute(key='certificates',
-                                path="./h5[starts-with(text(), " \
-                                        "'Certificat')]/..//text()",
-                                postprocess=makeSplitter('Certification:')),
-                            Attribute(key='seasons',
-                                path="./h5[starts-with(text(), " \
-                                        "'Seasons')]/..//text()",
-                                postprocess=makeSplitter('Seasons:')),
-                            Attribute(key='original air date',
-                                path="./h5[starts-with(text(), " \
-                                        "'Original Air Date')]/../div/text()"),
-                            Attribute(key='tv series link',
-                                path="./h5[starts-with(text(), " \
-                                        "'TV Series')]/..//a/@href"),
-                            Attribute(key='tv series title',
-                                path="./h5[starts-with(text(), " \
-                                        "'TV Series')]/..//a/text()")
-                            ]),
+        Extractor(
+            label='h5sections',
+            path="//div[@class='info']/h5/..",
+            attrs=[
+                Attribute(
+                    key="plot summary",
+                    path="./h5[starts-with(text(), 'Plot:')]/../div/text()",
+                    postprocess=lambda x: x.strip().rstrip('|').rstrip()
+                ),
+                Attribute(
+                    key="aspect ratio",
+                    path="./h5[starts-with(text(), 'Aspect')]/../div/text()",
+                    postprocess=lambda x: x.strip()
+                ),
+                Attribute(
+                    key="mpaa",
+                    path="./h5/a[starts-with(text(), 'MPAA')]/../../div/text()",
+                    postprocess=lambda x: x.strip()
+                ),
+                Attribute(
+                    key="countries",
+                    path="./h5[starts-with(text(), 'Countr')]/../div[@class='info-content']//text()",
+                    postprocess=makeSplitter('|')
+                ),
+                Attribute(
+                    key="language",
+                    path="./h5[starts-with(text(), 'Language')]/..//text()",
+                    postprocess=makeSplitter('Language:')
+                ),
+                Attribute(
+                    key='color info',
+                    path="./h5[starts-with(text(), 'Color')]/..//text()",
+                    postprocess=makeSplitter('|')
+                ),
+                Attribute(
+                    key='sound mix',
+                    path="./h5[starts-with(text(), 'Sound Mix')]/../div[@class='info-content']//text()",
+                    postprocess=makeSplitter()
+                ),
+                # Collects akas not encosed in <i> tags.
+                Attribute(
+                    key='other akas',
+                    path="./h5[starts-with(text(), 'Also Known As')]/../div//text()",
+                    postprocess=makeSplitter(
+                        sep='::', origNotesSep='" - ', newNotesSep='::', strip='"'
+                    )
+                ),
+                Attribute(
+                    key='runtimes',
+                    path="./h5[starts-with(text(), 'Runtime')]/../div/text()",
+                    postprocess=makeSplitter()
+                ),
+                Attribute(
+                    key='certificates',
+                    path="./h5[starts-with(text(), 'Certificat')]/..//text()",
+                    postprocess=makeSplitter('Certification:')
+                ),
+                Attribute(
+                    key='seasons',
+                    path="./h5[starts-with(text(), 'Seasons')]/..//text()",
+                    postprocess=makeSplitter('Seasons:')
+                ),
+                Attribute(
+                    key='original air date',
+                    path="./h5[starts-with(text(), 'Original Air Date')]/../div/text()"
+                ),
+                Attribute(
+                    key='tv series link',
+                    path="./h5[starts-with(text(), 'TV Series')]/..//a/@href"
+                ),
+                Attribute(
+                    key='tv series title',
+                    path="./h5[starts-with(text(), 'TV Series')]/..//a/text()"
+                )
+            ]
+        ),
 
-                Extractor(label='language codes',
-                            path="//h5[starts-with(text(), 'Language')]/..//a[starts-with(@href, '/language/')]",
-                            attrs=Attribute(key='language codes', multi=True,
-                                    path="./@href",
-                                    postprocess=lambda x: x.split('/')[2].strip()
-                                    )),
+        Extractor(
+            label='language codes',
+            path="//h5[starts-with(text(), 'Language')]/..//a[starts-with(@href, '/language/')]",
+            attrs=Attribute(
+                key='language codes',
+                multi=True,
+                path="./@href",
+                postprocess=lambda x: x.split('/')[2].strip()
+            )
+        ),
 
-                Extractor(label='country codes',
-                            path="//h5[starts-with(text(), 'Country')]/..//a[starts-with(@href, '/country/')]",
-                            attrs=Attribute(key='country codes', multi=True,
-                                    path="./@href",
-                                    postprocess=lambda x: x.split('/')[2].strip()
-                                    )),
+        Extractor(
+            label='country codes',
+            path="//h5[starts-with(text(), 'Country')]/..//a[starts-with(@href, '/country/')]",
+            attrs=Attribute(
+                key='country codes',
+                multi=True,
+                path="./@href",
+                postprocess=lambda x: x.split('/')[2].strip()
+            )
+        ),
 
-                Extractor(label='creator',
-                            path="//h5[starts-with(text(), 'Creator')]/..//a",
-                            attrs=Attribute(key='creator', multi=True,
-                                    path={'name': "./text()",
-                                        'link': "./@href"},
-                                    postprocess=lambda x: \
-                                        build_person(x.get('name') or u'',
-                                        personID=analyze_imdbid(x.get('link')))
-                                    )),
+        Extractor(
+            label='creator',
+            path="//h5[starts-with(text(), 'Creator')]/..//a",
+            attrs=Attribute(
+                key='creator',
+                multi=True,
+                path={
+                    'name': "./text()",
+                    'link': "./@href"
+                },
+                postprocess=lambda x: build_person(
+                    x.get('name') or u'',
+                    personID=analyze_imdbid(x.get('link'))
+                )
+            )
+        ),
 
-                Extractor(label='thin writer',
-                            path="//h5[starts-with(text(), 'Writer')]/..//a",
-                            attrs=Attribute(key='thin writer', multi=True,
-                                    path={'name': "./text()",
-                                        'link': "./@href"},
-                                    postprocess=lambda x: \
-                                        build_person(x.get('name') or u'',
-                                        personID=analyze_imdbid(x.get('link')))
-                                    )),
+        Extractor(
+            label='thin writer',
+            path="//h5[starts-with(text(), 'Writer')]/..//a",
+            attrs=Attribute(
+                key='thin writer',
+                multi=True,
+                path={
+                    'name': "./text()",
+                    'link': "./@href"
+                },
+                postprocess=lambda x: build_person(
+                    x.get('name') or u'',
+                    personID=analyze_imdbid(x.get('link'))
+                )
+            )
+        ),
 
-                Extractor(label='thin director',
-                            path="//h5[starts-with(text(), 'Director')]/..//a",
-                            attrs=Attribute(key='thin director', multi=True,
-                                    path={'name': "./text()",
-                                        'link': "@href"},
-                                    postprocess=lambda x: \
-                                        build_person(x.get('name') or u'',
-                                        personID=analyze_imdbid(x.get('link')))
-                                    )),
+        Extractor(
+            label='thin director',
+            path="//h5[starts-with(text(), 'Director')]/..//a",
+            attrs=Attribute(
+                key='thin director',
+                multi=True,
+                path={
+                    'name': "./text()",
+                    'link': "@href"
+                },
+                postprocess=lambda x: build_person(
+                    x.get('name') or u'',
+                    personID=analyze_imdbid(x.get('link'))
+                )
+            )
+        ),
 
-                Extractor(label='top 250/bottom 100',
-                            path="//div[@class='starbar-special']/" \
-                                    "a[starts-with(@href, '/chart/')]",
-                            attrs=Attribute(key='top/bottom rank',
-                                            path="./text()")),
+        Extractor(
+            label='top 250/bottom 100',
+            path="//div[@class='starbar-special']/a[starts-with(@href, '/chart/')]",
+            attrs=Attribute(
+                key='top/bottom rank',
+                path="./text()"
+            )
+        ),
 
-                Extractor(label='series years',
-                            path="//div[@id='tn15title']//span" \
-                                "[starts-with(text(), 'TV series')]",
-                            attrs=Attribute(key='series years',
-                                    path="./text()",
-                                    postprocess=lambda x: \
-                                            x.replace('TV series','').strip())),
+        Extractor(
+            label='series years',
+            path="//div[@id='tn15title']//span[starts-with(text(), 'TV series')]",
+            attrs=Attribute(
+                key='series years',
+                path="./text()",
+                postprocess=lambda x: x.replace('TV series', '').strip()
+            )
+        ),
 
-                Extractor(label='number of episodes',
-                            path="//a[@title='Full Episode List']",
-                            attrs=Attribute(key='number of episodes',
-                                    path="./text()",
-                                    postprocess=lambda x: \
-                                            _toInt(x, [(' Episodes', '')]))),
+        Extractor(
+            label='number of episodes',
+            path="//a[@title='Full Episode List']",
+            attrs=Attribute(
+                key='number of episodes',
+                path="./text()",
+                postprocess=lambda x: _toInt(x, [(' Episodes', '')])
+            )
+        ),
 
-                Extractor(label='episode number',
-                            path=".//div[@id='tn15epnav']",
-                            attrs=Attribute(key='episode number',
-                                    path="./text()",
-                                    postprocess=lambda x: int(re.sub(r'[^a-z0-9 ]', '', x.lower()).strip().split()[0]))),
+        Extractor(
+            label='episode number',
+            path=".//div[@id='tn15epnav']",
+            attrs=Attribute(
+                key='episode number',
+                path="./text()",
+                postprocess=lambda x: int(re.sub(r'[^a-z0-9 ]', '', x.lower())
+                                          .strip()
+                                          .split()[0])
+            )
+        ),
 
-                Extractor(label='previous episode',
-                            path=".//a[@title='Previous Episode']",
-                            attrs=Attribute(key='previous episode',
-                                    path="./@href",
-                                    postprocess=lambda x: analyze_imdbid(x))),
+        Extractor(
+            label='previous episode',
+            path=".//a[@title='Previous Episode']",
+            attrs=Attribute(
+                key='previous episode',
+                path="./@href",
+                postprocess=lambda x: analyze_imdbid(x)
+            )
+        ),
 
-                Extractor(label='next episode',
-                            path=".//a[@title='Next Episode']",
-                            attrs=Attribute(key='next episode',
-                                    path="./@href",
-                                    postprocess=lambda x: analyze_imdbid(x))),
+        Extractor(
+            label='next episode',
+            path=".//a[@title='Next Episode']",
+            attrs=Attribute(
+                key='next episode',
+                path="./@href",
+                postprocess=lambda x: analyze_imdbid(x)
+            )
+        ),
 
-                Extractor(label='akas',
-                        path="//i[@class='transl']",
-                        attrs=Attribute(key='akas', multi=True, path='text()',
-                                postprocess=lambda x:
-                                x.replace('  ', ' ').rstrip('-').replace('" - ',
-                                    '"::', 1).strip('"').replace('  ', ' '))),
+        Extractor(
+            label='akas',
+            path="//i[@class='transl']",
+            attrs=Attribute(
+                key='akas',
+                multi=True,
+                path='text()',
+                postprocess=lambda x: x
+                    .replace('  ', ' ')
+                    .rstrip('-')
+                    .replace('" - ', '"::', 1)
+                    .strip('"')
+                    .replace('  ', ' ')
+            )
+        ),
 
-                Extractor(label='production notes/status',
-                        path="//h5[starts-with(text(), 'Status:')]/..//div[@class='info-content']",
-                        attrs=Attribute(key='production status',
-                                path=".//text()",
-                                postprocess=lambda x: x.strip().split('|')[0].strip().lower())),
+        Extractor(
+            label='production notes/status',
+            path="//h5[starts-with(text(), 'Status:')]/..//div[@class='info-content']",
+            attrs=Attribute(
+                key='production status',
+                path=".//text()",
+                postprocess=lambda x: x.strip().split('|')[0].strip().lower()
+            )
+        ),
 
-                Extractor(label='production notes/status updated',
-                        path="//h5[starts-with(text(), 'Status Updated:')]/..//div[@class='info-content']",
-                        attrs=Attribute(key='production status updated',
-                                path=".//text()",
-                                postprocess=lambda x: x.strip())),
+        Extractor(
+            label='production notes/status updated',
+            path="//h5[starts-with(text(), 'Status Updated:')]/..//div[@class='info-content']",
+            attrs=Attribute(
+                key='production status updated',
+                path=".//text()",
+                postprocess=lambda x: x.strip()
+            )
+        ),
 
-                Extractor(label='production notes/comments',
-                        path="//h5[starts-with(text(), 'Comments:')]/..//div[@class='info-content']",
-                        attrs=Attribute(key='production comments',
-                                path=".//text()",
-                                postprocess=lambda x: x.strip())),
+        Extractor(
+            label='production notes/comments',
+            path="//h5[starts-with(text(), 'Comments:')]/..//div[@class='info-content']",
+            attrs=Attribute(
+                key='production comments',
+                path=".//text()",
+                postprocess=lambda x: x.strip()
+            )
+        ),
 
-                Extractor(label='production notes/note',
-                        path="//h5[starts-with(text(), 'Note:')]/..//div[@class='info-content']",
-                        attrs=Attribute(key='production note',
-                                path=".//text()",
-                                postprocess=lambda x: x.strip())),
+        Extractor(
+            label='production notes/note',
+            path="//h5[starts-with(text(), 'Note:')]/..//div[@class='info-content']",
+            attrs=Attribute(
+                key='production note',
+                path=".//text()",
+                postprocess=lambda x: x.strip()
+            )
+        ),
 
-                Extractor(label='blackcatheader',
-                        group="//b[@class='blackcatheader']",
-                        group_key="./text()",
-                        group_key_normalize=lambda x: x.lower(),
-                        path="../ul/li",
-                        attrs=Attribute(key=None,
-                                multi=True,
-                                path={'name': "./a//text()",
-                                        'comp-link': "./a/@href",
-                                        'notes': "./text()"},
-                                postprocess=lambda x: \
-                                        Company(name=x.get('name') or u'',
-                                companyID=analyze_imdbid(x.get('comp-link')),
-                                notes=(x.get('notes') or u'').strip())
-                            )),
+        Extractor(
+            label='blackcatheader',
+            group="//b[@class='blackcatheader']",
+            group_key="./text()",
+            group_key_normalize=lambda x: x.lower(),
+            path="../ul/li",
+            attrs=Attribute(
+                key=None,
+                multi=True,
+                path={
+                    'name': "./a//text()",
+                    'comp-link': "./a/@href",
+                    'notes': "./text()"
+                },
+                postprocess=lambda x: Company(name=x.get('name') or u'',
+                                              companyID=analyze_imdbid(x.get('comp-link')),
+                                              notes=(x.get('notes') or u'').strip())
+            )
+        ),
 
-                Extractor(label='rating',
-                        path="//div[@class='starbar-meta']/b",
-                        attrs=Attribute(key='rating',
-                                        path=".//text()")),
+        Extractor(
+            label='rating',
+            path="//div[@class='starbar-meta']/b",
+            attrs=Attribute(
+                key='rating',
+                path=".//text()"
+            )
+        ),
 
-                Extractor(label='votes',
-                        path="//div[@class='starbar-meta']/a[@href]",
-                        attrs=Attribute(key='votes',
-                                        path=".//text()")),
+        Extractor(
+            label='votes',
+            path="//div[@class='starbar-meta']/a[@href]",
+            attrs=Attribute(
+                key='votes',
+                path=".//text()"
+            )
+        ),
 
-                Extractor(label='cover url',
-                        path="//a[@name='poster']",
-                        attrs=Attribute(key='cover url',
-                                        path="./img/@src"))
-                ]
+        Extractor(
+            label='cover url',
+            path="//a[@name='poster']",
+            attrs=Attribute(
+                key='cover url',
+                path="./img/@src"
+            )
+        )
+    ]
 
     preprocessors = [
-        (re.compile(r'(<b class="blackcatheader">.+?</b>)', re.I),
-            r'</div><div>\1'),
+        (re.compile(r'(<b class="blackcatheader">.+?</b>)', re.I), r'</div><div>\1'),
         ('<small>Full cast and crew for<br>', ''),
         ('<td> </td>', '<td>...</td>'),
         (re.compile(r'<span class="tv-extra">TV mini-series(\s+.*?)</span>', re.I),
-            r'<span class="tv-extra">TV series\1</span> (mini)'),
+         r'<span class="tv-extra">TV series\1</span> (mini)'),
         (_reRolesMovie, _manageRoles),
-        (_reAkas, _replaceBR)]
+        (_reAkas, _replaceBR)
+    ]
 
     def preprocess_dom(self, dom):
         # Handle series information.
         xpath = self.xpath(dom, "//b[text()='Series Crew']")
         if xpath:
-            b = xpath[-1] # In doubt, take the last one.
+            b = xpath[-1]   # In doubt, take the last one.
             for a in self.xpath(b, "./following::h5/a[@class='glossary']"):
                 name = a.get('name')
                 if name:
@@ -443,13 +576,13 @@ class DOMHTMLMovieParser(DOMParserBase):
             proLink.drop_tree()
         # Remove some 'more' links (keep others, like the one around
         # the number of votes).
-        for tn15more in self.xpath(dom,
-                    "//a[@class='tn15more'][starts-with(@href, '/title/')]"):
+        for tn15more in self.xpath(dom, "//a[@class='tn15more'][starts-with(@href, '/title/')]"):
             tn15more.drop_tree()
         return dom
 
     re_space = re.compile(r'\s+')
     re_airdate = re.compile(r'(.*)\s*\(season (\d+), episode (\d+)\)', re.I)
+
     def postprocess_data(self, data):
         # Convert section names.
         for sect in data.keys():
@@ -498,18 +631,22 @@ class DOMHTMLMovieParser(DOMParserBase):
             if aid and len(aid[0]) == 3:
                 date, season, episode = aid[0]
                 date = date.strip()
-                try: season = int(season)
-                except: pass
-                try: episode = int(episode)
-                except: pass
+                try:
+                    season = int(season)
+                except:
+                    pass
+                try:
+                    episode = int(episode)
+                except:
+                    pass
                 if date and date != '????':
                     data['original air date'] = date
                 else:
                     del data['original air date']
                 # Handle also "episode 0".
-                if season or type(season) is type(0):
+                if season or isinstance(season, int):
                     data['season'] = season
-                if episode or type(season) is type(0):
+                if episode or isinstance(season, int):
                     data['episode'] = episode
         for k in ('writer', 'director'):
             t_k = 'thin %s' % k
@@ -534,10 +671,9 @@ class DOMHTMLMovieParser(DOMParserBase):
         if 'tv series link' in data:
             if 'tv series title' in data:
                 data['episode of'] = Movie(title=data['tv series title'],
-                                            movieID=analyze_imdbid(
-                                                    data['tv series link']),
-                                            accessSystem=self._as,
-                                            modFunct=self._modFunct)
+                                           movieID=analyze_imdbid(data['tv series link']),
+                                           accessSystem=self._as,
+                                           modFunct=self._modFunct)
                 del data['tv series title']
             del data['tv series link']
         if 'rating' in data:
@@ -562,6 +698,7 @@ def _process_plotsummary(x):
         xplot += u'::%s' % xauthor
     return xplot
 
+
 class DOMHTMLPlotParser(DOMParserBase):
     """Parser for the "plot summary" page of a given movie.
     The page should be provided as a string, as taken from
@@ -577,13 +714,20 @@ class DOMHTMLPlotParser(DOMParserBase):
 
     # Notice that recently IMDb started to put the email of the
     # author only in the link, that we're not collecting, here.
-    extractors = [Extractor(label='plot',
-                            path="//ul[@class='zebraList']/li",
-                            attrs=Attribute(key='plot',
-                                            multi=True,
-                                            path={'plot': './/p[@class="plotSummary"]//text()',
-                                                  'author': './/span/em/a/text()'},
-                                            postprocess=_process_plotsummary))]
+    extractors = [
+        Extractor(
+            label='plot',
+            path="//ul[@class='zebraList']/li",
+            attrs=Attribute(
+                key='plot',
+                multi=True,
+                path={
+                    'plot': './/p[@class="plotSummary"]//text()',
+                    'author': './/span/em/a/text()'
+                },
+                postprocess=_process_plotsummary)
+        )
+    ]
 
 
 def _process_award(x):
@@ -613,7 +757,6 @@ def _process_award(x):
     return award
 
 
-
 class DOMHTMLAwardsParser(DOMParserBase):
     """Parser for the "awards" page of a given person or movie.
     The page should be provided as a string, as taken from
@@ -628,12 +771,13 @@ class DOMHTMLAwardsParser(DOMParserBase):
     _containsObjects = True
 
     extractors = [
-        Extractor(label='awards',
+        Extractor(
+            label='awards',
             group="//table//big",
             group_key="./a",
-            path="./ancestor::tr[1]/following-sibling::tr/" \
-                    "td[last()][not(@colspan)]",
-            attrs=Attribute(key=None,
+            path="./ancestor::tr[1]/following-sibling::tr/td[last()][not(@colspan)]",
+            attrs=Attribute(
+                key=None,
                 multi=True,
                 path={
                     'year': "../td[1]/a/text()",
@@ -641,26 +785,29 @@ class DOMHTMLAwardsParser(DOMParserBase):
                     'award': "../td[3]/text()",
                     'category': "./text()[1]",
                     # FIXME: takes only the first co-recipient
-                    'with': "./small[starts-with(text()," \
-                            " 'Shared with:')]/following-sibling::a[1]/text()",
+                    'with': "./small[starts-with(text(), 'Shared with:')]/following-sibling::a[1]/text()",
                     'notes': "./small[last()]//text()",
                     'anchor': ".//text()"
-                    },
+                },
                 postprocess=_process_award
-                )),
-        Extractor(label='recipients',
+            )
+        ),
+
+        Extractor(
+            label='recipients',
             group="//table//big",
             group_key="./a",
-            path="./ancestor::tr[1]/following-sibling::tr/" \
-                    "td[last()]/small[1]/preceding-sibling::a",
-            attrs=Attribute(key=None,
+            path="./ancestor::tr[1]/following-sibling::tr/td[last()]/small[1]/preceding-sibling::a",
+            attrs=Attribute(
+                key=None,
                 multi=True,
                 path={
                     'name': "./text()",
                     'link': "./@href",
                     'anchor': "..//text()"
-                    }
-                ))
+                }
+            )
+        )
     ]
 
     preprocessors = [
@@ -671,7 +818,7 @@ class DOMHTMLAwardsParser(DOMParserBase):
         (re.compile('(<table[^>]*>\n\n)</table>(<table)', re.I), r'\1\2'),
         (re.compile('(<small>.*?)<br>(.*?</small)', re.I), r'\1 \2'),
         (re.compile('(</tr>\n\n)(<td)', re.I), r'\1<tr>\2')
-        ]
+    ]
 
     def preprocess_dom(self, dom):
         """Repeat td elements according to their rowspan attributes
@@ -707,17 +854,20 @@ class DOMHTMLAwardsParser(DOMParserBase):
                     entry['assigner'] = assigner.strip()
                     # find the recipients
                     matches = [p for p in data[key]
-                               if p.has_key('name') and (entry['anchor'] ==
-                                   p['anchor'])]
+                               if 'name' in p and (entry['anchor'] == p['anchor'])]
                     if self.subject == 'title':
-                        recipients = [Person(name=recipient['name'],
-                                    personID=analyze_imdbid(recipient['link']))
-                                    for recipient in matches]
+                        recipients = [
+                            Person(name=recipient['name'],
+                                   personID=analyze_imdbid(recipient['link']))
+                            for recipient in matches
+                        ]
                         entry['to'] = recipients
                     elif self.subject == 'name':
-                        recipients = [Movie(title=recipient['name'],
-                                    movieID=analyze_imdbid(recipient['link']))
-                                    for recipient in matches]
+                        recipients = [
+                            Movie(title=recipient['name'],
+                                  movieID=analyze_imdbid(recipient['link']))
+                            for recipient in matches
+                        ]
                         entry['for'] = recipients
                     nd.append(entry)
                 del entry['anchor']
@@ -734,11 +884,17 @@ class DOMHTMLTaglinesParser(DOMParserBase):
         tparser = DOMHTMLTaglinesParser()
         result = tparser.parse(taglines_html_string)
     """
-    extractors = [Extractor(label='taglines',
-                            path="//div[@id='taglines_content']/div",
-                            attrs=Attribute(key='taglines',
-                                            multi=True,
-                                            path=".//text()"))]
+    extractors = [
+        Extractor(
+            label='taglines',
+            path="//div[@id='taglines_content']/div",
+            attrs=Attribute(
+                key='taglines',
+                multi=True,
+                path=".//text()"
+            )
+        )
+    ]
 
     def preprocess_dom(self, dom):
         for node in self.xpath(dom, "//div[@id='taglines_content']/div[@class='header']"):
@@ -763,12 +919,17 @@ class DOMHTMLKeywordsParser(DOMParserBase):
         kwparser = DOMHTMLKeywordsParser()
         result = kwparser.parse(keywords_html_string)
     """
-    extractors = [Extractor(label='keywords',
-                            path="//a[starts-with(@href, '/keyword/')]",
-                            attrs=Attribute(key='keywords',
-                                            path="./text()", multi=True,
-                                            postprocess=lambda x: \
-                                                x.lower().replace(' ', '-')))]
+    extractors = [
+        Extractor(
+            label='keywords',
+            path="//a[starts-with(@href, '/keyword/')]",
+            attrs=Attribute(
+                key='keywords',
+                path="./text()", multi=True,
+                postprocess=lambda x: x.lower().replace(' ', '-')
+            )
+        )
+    ]
 
 
 class DOMHTMLAlternateVersionsParser(DOMParserBase):
@@ -782,12 +943,19 @@ class DOMHTMLAlternateVersionsParser(DOMParserBase):
         result = avparser.parse(alternateversions_html_string)
     """
     _defGetRefs = True
-    extractors = [Extractor(label='alternate versions',
-                            path="//ul[@class='trivia']/li",
-                            attrs=Attribute(key='alternate versions',
-                                            multi=True,
-                                            path=".//text()",
-                                            postprocess=lambda x: x.strip()))]
+
+    extractors = [
+        Extractor(
+            label='alternate versions',
+            path="//ul[@class='trivia']/li",
+            attrs=Attribute(
+                key='alternate versions',
+                multi=True,
+                path=".//text()",
+                postprocess=lambda x: x.strip()
+            )
+        )
+    ]
 
 
 class DOMHTMLTriviaParser(DOMParserBase):
@@ -801,12 +969,18 @@ class DOMHTMLTriviaParser(DOMParserBase):
         result = avparser.parse(alternateversions_html_string)
     """
     _defGetRefs = True
-    extractors = [Extractor(label='alternate versions',
-                            path="//div[@class='sodatext']",
-                            attrs=Attribute(key='trivia',
-                                            multi=True,
-                                            path=".//text()",
-                                            postprocess=lambda x: x.strip()))]
+
+    extractors = [
+        Extractor(
+            label='alternate versions',
+            path="//div[@class='sodatext']",
+            attrs=Attribute(
+                key='trivia',
+                multi=True,
+                path=".//text()",
+                postprocess=lambda x: x.strip())
+        )
+    ]
 
     def preprocess_dom(self, dom):
         # Remove "link this quote" links.
@@ -815,16 +989,21 @@ class DOMHTMLTriviaParser(DOMParserBase):
         return dom
 
 
-
 class DOMHTMLSoundtrackParser(DOMParserBase):
     _defGetRefs = True
     preprocessors = [('<br />', '\n'), ('<br>', '\n')]
-    extractors = [Extractor(label='soundtrack',
-                            path="//div[@class='list']//div",
-                            attrs=Attribute(key='soundtrack',
-                                            multi=True,
-                                            path=".//text()",
-                                            postprocess=lambda x: x.strip()))]
+    extractors = [
+        Extractor(
+            label='soundtrack',
+            path="//div[@class='list']//div",
+            attrs=Attribute(
+                key='soundtrack',
+                multi=True,
+                path=".//text()",
+                postprocess=lambda x: x.strip()
+            )
+        )
+    ]
 
     def postprocess_data(self, data):
         if 'soundtrack' in data:
@@ -881,11 +1060,18 @@ class DOMHTMLCrazyCreditsParser(DOMParserBase):
     """
     _defGetRefs = True
 
-    extractors = [Extractor(label='crazy credits', path="//ul/li/tt",
-                            attrs=Attribute(key='crazy credits', multi=True,
-                                path=".//text()",
-                                postprocess=lambda x: \
-                                    x.replace('\n', ' ').replace('  ', ' ')))]
+    extractors = [
+        Extractor(
+            label='crazy credits',
+            path="//ul/li/tt",
+            attrs=Attribute(
+                key='crazy credits',
+                multi=True,
+                path=".//text()",
+                postprocess=lambda x: x.replace('\n', ' ').replace('  ', ' ')
+            )
+        )
+    ]
 
 
 def _process_goof(x):
@@ -907,14 +1093,22 @@ class DOMHTMLGoofsParser(DOMParserBase):
     """
     _defGetRefs = True
 
-    extractors = [Extractor(label='goofs', path="//div[@class='soda odd']",
-                    attrs=Attribute(key='goofs', multi=True,
-                        path={
-                              'text':"./text()",
-                              'category':'./preceding-sibling::h4[1]/text()',
-                              'spoiler_category': './h4/text()'
-                        },
-                        postprocess=_process_goof))]
+    extractors = [
+        Extractor(
+            label='goofs',
+            path="//div[@class='soda odd']",
+            attrs=Attribute(
+                key='goofs',
+                multi=True,
+                path={
+                    'text': "./text()",
+                    'category': './preceding-sibling::h4[1]/text()',
+                    'spoiler_category': './h4/text()'
+                },
+                postprocess=_process_goof
+            )
+        )
+    ]
 
 
 class DOMHTMLQuotesParser(DOMParserBase):
@@ -930,21 +1124,36 @@ class DOMHTMLQuotesParser(DOMParserBase):
     _defGetRefs = True
 
     extractors = [
-        Extractor(label='quotes_odd',
+        Extractor(
+            label='quotes_odd',
             path="//div[@class='quote soda odd']",
-            attrs=Attribute(key='quotes_odd',
+            attrs=Attribute(
+                key='quotes_odd',
                 multi=True,
                 path=".//text()",
-                postprocess=lambda x: x.strip().replace(' \n',
-                            '::').replace('::\n', '::').replace('\n', ' '))),
-        Extractor(label='quotes_even',
+                postprocess=lambda x: x
+                    .strip()
+                    .replace(' \n', '::')
+                    .replace('::\n', '::')
+                    .replace('\n', ' ')
+            )
+        ),
+
+        Extractor(
+            label='quotes_even',
             path="//div[@class='quote soda even']",
-            attrs=Attribute(key='quotes_even',
+            attrs=Attribute(
+                key='quotes_even',
                 multi=True,
                 path=".//text()",
-                postprocess=lambda x: x.strip().replace(' \n',
-                            '::').replace('::\n', '::').replace('\n', ' ')))
-        ]
+                postprocess=lambda x: x
+                    .strip()
+                    .replace(' \n', '::')
+                    .replace('::\n', '::')
+                    .replace('\n', ' ')
+            )
+        )
+    ]
 
     preprocessors = [
         (re.compile('<a href="#" class="hidesoda hidden">Hide options</a><br>', re.I), '')
@@ -976,33 +1185,53 @@ class DOMHTMLReleaseinfoParser(DOMParserBase):
         rdparser = DOMHTMLReleaseinfoParser()
         result = rdparser.parse(releaseinfo_html_string)
     """
-    extractors = [Extractor(label='release dates',
-                    path="//table[@id='release_dates']//tr",
-                    attrs=Attribute(key='release dates', multi=True,
-                        path={'country': ".//td[1]//text()",
-                            'date': ".//td[2]//text()",
-                            'notes': ".//td[3]//text()"})),
-                Extractor(label='akas',
-                    path="//table[@id='akas']//tr",
-                    attrs=Attribute(key='akas', multi=True,
-                        path={'title': "./td[1]/text()",
-                            'countries': "./td[2]/text()"}))]
+    extractors = [
+        Extractor(
+            label='release dates',
+            path="//table[@id='release_dates']//tr",
+            attrs=Attribute(
+                key='release dates',
+                multi=True,
+                path={
+                    'country': ".//td[1]//text()",
+                    'date': ".//td[2]//text()",
+                    'notes': ".//td[3]//text()"
+                }
+            )
+        ),
+
+        Extractor(
+            label='akas',
+            path="//table[@id='akas']//tr",
+            attrs=Attribute(
+                key='akas',
+                multi=True,
+                path={
+                    'title': "./td[1]/text()",
+                    'countries': "./td[2]/text()"}
+            )
+        )
+    ]
 
     preprocessors = [
         (re.compile('(<h5><a name="?akas"?.*</table>)', re.I | re.M | re.S),
-            r'<div class="_imdbpy_akas">\1</div>')]
+         r'<div class="_imdbpy_akas">\1</div>')
+    ]
 
     def postprocess_data(self, data):
-        if not ('release dates' in data or 'akas' in data): return data
+        if not ('release dates' in data or 'akas' in data):
+            return data
         releases = data.get('release dates') or []
         rl = []
         for i in releases:
             country = i.get('country')
             date = i.get('date')
-            if not (country and date): continue
+            if not (country and date):
+                continue
             country = country.strip()
             date = date.strip()
-            if not (country and date): continue
+            if not (country and date):
+                continue
             notes = i['notes']
             info = u'%s::%s' % (country, date)
             if notes:
@@ -1041,39 +1270,65 @@ class DOMHTMLRatingsParser(DOMParserBase):
         rparser = DOMHTMLRatingsParser()
         result = rparser.parse(userratings_html_string)
     """
-    re_means = re.compile('mean\s*=\s*([0-9]\.[0-9])\.\s*median\s*=\s*([0-9])',
-                          re.I)
+    re_means = re.compile('mean\s*=\s*([0-9]\.[0-9])\.\s*median\s*=\s*([0-9])', re.I)
+
     extractors = [
-        Extractor(label='number of votes',
+        Extractor(
+            label='number of votes',
             path="//td[b='Percentage']/../../tr",
-            attrs=[Attribute(key='votes',
-                            multi=True,
-                            path={
-                                'votes': "td[1]//text()",
-                                'ordinal': "td[3]//text()"
-                                })]),
-        Extractor(label='mean and median',
+            attrs=[
+                Attribute(
+                    key='votes',
+                    multi=True,
+                    path={
+                        'votes': "td[1]//text()",
+                        'ordinal': "td[3]//text()"
+                    }
+                )
+            ]
+        ),
+
+        Extractor(
+            label='mean and median',
             path="//p[starts-with(text(), 'Arithmetic mean')]",
-            attrs=Attribute(key='mean and median',
-                            path="text()")),
-        Extractor(label='rating',
+            attrs=Attribute(
+                key='mean and median',
+                path="text()"
+            )
+        ),
+
+        Extractor(
+            label='rating',
             path="//a[starts-with(@href, '/search/title?user_rating=')]",
-            attrs=Attribute(key='rating',
-                            path="text()")),
-        Extractor(label='demographic voters',
+            attrs=Attribute(
+                key='rating',
+                path="text()"
+            )
+        ),
+
+        Extractor(
+            label='demographic voters',
             path="//td[b='Average']/../../tr",
-            attrs=Attribute(key='demographic voters',
-                            multi=True,
-                            path={
-                                'voters': "td[1]//text()",
-                                'votes': "td[2]//text()",
-                                'average': "td[3]//text()"
-                                })),
-        Extractor(label='top 250',
+            attrs=Attribute(
+                key='demographic voters',
+                multi=True,
+                path={
+                    'voters': "td[1]//text()",
+                    'votes': "td[2]//text()",
+                    'average': "td[3]//text()"
+                }
+            )
+        ),
+
+        Extractor(
+            label='top 250',
             path="//a[text()='top 250']",
-            attrs=Attribute(key='top 250',
-                            path="./preceding-sibling::text()[1]"))
-        ]
+            attrs=Attribute(
+                key='top 250',
+                path="./preceding-sibling::text()[1]"
+            )
+        )
+    ]
 
     def postprocess_data(self, data):
         nd = {}
@@ -1083,20 +1338,23 @@ class DOMHTMLRatingsParser(DOMParserBase):
             for i in xrange(1, 11):
                 _ordinal = int(votes[i]['ordinal'])
                 _strvts = votes[i]['votes'] or '0'
-                nd['number of votes'][_ordinal] = \
-                        int(_strvts.replace(',', ''))
+                nd['number of votes'][_ordinal] = int(_strvts.replace(',', ''))
         mean = data.get('mean and median', '')
         if mean:
             means = self.re_means.findall(mean)
             if means and len(means[0]) == 2:
                 am, med = means[0]
-                try: am = float(am)
-                except (ValueError, OverflowError): pass
-                if type(am) is type(1.0):
+                try:
+                    am = float(am)
+                except (ValueError, OverflowError):
+                    pass
+                if isinstance(am, float):
                     nd['arithmetic mean'] = am
-                try: med = int(med)
-                except (ValueError, OverflowError): pass
-                if type(med) is type(0):
+                try:
+                    med = int(med)
+                except (ValueError, OverflowError):
+                    pass
+                if isinstance(med, int):
                     nd['median'] = med
         if 'rating' in data:
             nd['rating'] = float(data['rating'])
@@ -1104,11 +1362,10 @@ class DOMHTMLRatingsParser(DOMParserBase):
         if dem_voters:
             nd['demographic'] = {}
             for i in xrange(1, len(dem_voters)):
-                if (dem_voters[i]['votes'] is not None) \
-                   and (dem_voters[i]['votes'].strip()):
-                    nd['demographic'][dem_voters[i]['voters'].strip().lower()] \
-                                = (int(dem_voters[i]['votes'].replace(',', '')),
-                            float(dem_voters[i]['average']))
+                if (dem_voters[i]['votes'] is not None) and (dem_voters[i]['votes'].strip()):
+                    nd['demographic'][dem_voters[i]['voters'].strip().lower()] = \
+                        (int(dem_voters[i]['votes'].replace(',', '')),
+                         float(dem_voters[i]['average']))
         if 'imdb users' in nd.get('demographic', {}):
             nd['votes'] = nd['demographic']['imdb users'][0]
             nd['demographic']['all votes'] = nd['demographic']['imdb users']
@@ -1119,9 +1376,11 @@ class DOMHTMLRatingsParser(DOMParserBase):
             i = sd.find(' ')
             if i != -1:
                 sd = sd[:i]
-                try: sd = int(sd)
-                except (ValueError, OverflowError): pass
-                if type(sd) is type(0):
+                try:
+                    sd = int(sd)
+                except (ValueError, OverflowError):
+                    pass
+                if isinstance(sd, int):
                     nd['top 250 rank'] = sd
         return nd
 
@@ -1138,19 +1397,36 @@ class DOMHTMLEpisodesRatings(DOMParserBase):
     """
     _containsObjects = True
 
-    extractors = [Extractor(label='title', path="//title",
-                            attrs=Attribute(key='title', path="./text()")),
-                Extractor(label='ep ratings',
-                        path="//th/../..//tr",
-                        attrs=Attribute(key='episodes', multi=True,
-                                path={'nr': ".//td[1]/text()",
-                                        'ep title': ".//td[2]//text()",
-                                        'movieID': ".//td[2]/a/@href",
-                                        'rating': ".//td[3]/text()",
-                                        'votes': ".//td[4]/text()"}))]
+    extractors = [
+        Extractor(
+            label='title',
+            path="//title",
+            attrs=Attribute(
+                key='title',
+                path="./text()"
+            )
+        ),
+
+        Extractor(
+            label='ep ratings',
+            path="//th/../..//tr",
+            attrs=Attribute(
+                key='episodes',
+                multi=True,
+                path={
+                    'nr': ".//td[1]/text()",
+                    'ep title': ".//td[2]//text()",
+                    'movieID': ".//td[2]/a/@href",
+                    'rating': ".//td[3]/text()",
+                    'votes': ".//td[4]/text()"
+                }
+            )
+        )
+    ]
 
     def postprocess_data(self, data):
-        if 'title' not in data or 'episodes' not in data: return {}
+        if 'title' not in data or 'episodes' not in data:
+            return {}
         nd = []
         title = data['title']
         for i in data['episodes']:
@@ -1158,7 +1434,8 @@ class DOMHTMLEpisodesRatings(DOMParserBase):
             movieID = analyze_imdbid(i['movieID'])
             votes = i['votes']
             rating = i['rating']
-            if not (ept and movieID and votes and rating): continue
+            if not (ept and movieID and votes and rating):
+                continue
             try:
                 votes = int(votes.replace(',', '').replace('.', ''))
             except:
@@ -1176,21 +1453,23 @@ class DOMHTMLEpisodesRatings(DOMParserBase):
             if movieID is not None:
                 movieID = str(movieID)
             m = Movie(title=ept, movieID=movieID, accessSystem=self._as,
-                        modFunct=self._modFunct)
+                      modFunct=self._modFunct)
             epofdict = m.get('episode of')
             if epofdict is not None:
                 m['episode of'] = Movie(data=epofdict, accessSystem=self._as,
-                        modFunct=self._modFunct)
+                                        modFunct=self._modFunct)
             nd.append({'episode': m, 'votes': votes, 'rating': rating})
         return {'episodes rating': nd}
 
 
 def _normalize_href(href):
     if (href is not None) and (not href.lower().startswith('http://')):
-        if href.startswith('/'): href = href[1:]
+        if href.startswith('/'):
+            href = href[1:]
         # TODO: imdbURL_base may be set by the user!
         href = '%s%s' % (imdbURL_base, href)
     return href
+
 
 class DOMHTMLCriticReviewsParser(DOMParserBase):
     """Parser for the "critic reviews" pages of a given movie.
@@ -1205,14 +1484,25 @@ class DOMHTMLCriticReviewsParser(DOMParserBase):
     kind = 'critic reviews'
 
     extractors = [
-        Extractor(label='metascore',
-                path="//div[@class='metascore_wrap']/div/span",
-                attrs=Attribute(key='metascore',
-                                path=".//text()")),
-        Extractor(label='metacritic url',
-                path="//div[@class='article']/div[@class='see-more']/a",
-                attrs=Attribute(key='metacritic url',
-                                path="./@href")) ]
+        Extractor(
+            label='metascore',
+            path="//div[@class='metascore_wrap']/div/span",
+            attrs=Attribute(
+                key='metascore',
+                path=".//text()"
+            )
+        ),
+
+        Extractor(
+            label='metacritic url',
+            path="//div[@class='article']/div[@class='see-more']/a",
+            attrs=Attribute(
+                key='metacritic url',
+                path="./@href"
+            )
+        )
+    ]
+
 
 class DOMHTMLOfficialsitesParser(DOMParserBase):
     """Parser for the "official sites", "external reviews", "newsgroup
@@ -1229,17 +1519,23 @@ class DOMHTMLOfficialsitesParser(DOMParserBase):
     kind = 'official sites'
 
     extractors = [
-        Extractor(label='site',
-            path="//ul/li/a",
-            attrs=Attribute(key='self.kind',
+        Extractor(
+            label='site',
+            path="//ol/li/a",
+            attrs=Attribute(
+                key='self.kind',
                 multi=True,
                 path={
                     'link': "./@href",
                     'info': "./text()"
                 },
-                postprocess=lambda x: (x.get('info').strip(),
-                            urllib.unquote(_normalize_href(x.get('link'))))))
-        ]
+                postprocess=lambda x: (
+                    x.get('info').strip(),
+                    urllib.unquote(_normalize_href(x.get('link')))
+                )
+            )
+        )
+    ]
 
 
 class DOMHTMLConnectionParser(DOMParserBase):
@@ -1254,15 +1550,23 @@ class DOMHTMLConnectionParser(DOMParserBase):
     """
     _containsObjects = True
 
-    extractors = [Extractor(label='connection',
-                    group="//div[@class='_imdbpy']",
-                    group_key="./h5/text()",
-                    group_key_normalize=lambda x: x.lower(),
-                    path="./a",
-                    attrs=Attribute(key=None,
-                                    path={'title': "./text()",
-                                            'movieID': "./@href"},
-                                    multi=True))]
+    extractors = [
+        Extractor(
+            label='connection',
+            group="//div[@class='_imdbpy']",
+            group_key="./h5/text()",
+            group_key_normalize=lambda x: x.lower(),
+            path="./a",
+            attrs=Attribute(
+                key=None,
+                path={
+                    'title': "./text()",
+                    'movieID': "./@href"
+                },
+                multi=True
+            )
+        )
+    ]
 
     preprocessors = [
         ('<h5>', '</div><div class="_imdbpy"><h5>'),
@@ -1270,7 +1574,7 @@ class DOMHTMLConnectionParser(DOMParserBase):
         ('</a> (', ' ('),
         ('\n<br/>', '</a>'),
         ('<br/> - ', '::')
-        ]
+    ]
 
     def postprocess_data(self, data):
         for key in data.keys():
@@ -1282,13 +1586,12 @@ class DOMHTMLConnectionParser(DOMParserBase):
                 notes = u''
                 if len(ts) == 2:
                     notes = ts[1].strip()
-                m = Movie(title=title,
-                            movieID=analyze_imdbid(v['movieID']),
-                            accessSystem=self._as, notes=notes,
-                            modFunct=self._modFunct)
+                m = Movie(title=title, movieID=analyze_imdbid(v['movieID']),
+                          accessSystem=self._as, notes=notes, modFunct=self._modFunct)
                 nl.append(m)
             data[key] = nl
-        if not data: return {}
+        if not data:
+            return {}
         return {'connections': data}
 
 
@@ -1302,14 +1605,26 @@ class DOMHTMLLocationsParser(DOMParserBase):
         lparser = DOMHTMLLocationsParser()
         result = lparser.parse(locations_html_string)
     """
-    extractors = [Extractor(label='locations', path="//dt",
-                    attrs=Attribute(key='locations', multi=True,
-                                path={'place': ".//text()",
-                                        'note': "./following-sibling::dd[1]" \
-                                                "//text()"},
-                                postprocess=lambda x: (u'%s::%s' % (
-                                    x['place'].strip(),
-                                    (x['note'] or u'').strip())).strip(':')))]
+    extractors = [
+        Extractor(
+            label='locations',
+            path="//dt",
+            attrs=Attribute(
+                key='locations',
+                multi=True,
+                path={
+                    'place': ".//text()",
+                    'note': "./following-sibling::dd[1]//text()"
+                },
+                postprocess=lambda x: (
+                    u'%s::%s' % (
+                        x['place'].strip(),
+                        (x['note'] or u'').strip()
+                    )
+                ).strip(':')
+            )
+        )
+    ]
 
 
 class DOMHTMLTechParser(DOMParserBase):
@@ -1326,28 +1641,32 @@ class DOMHTMLTechParser(DOMParserBase):
     kind = 'tech'
     re_space = re.compile(r'\s+')
 
-    extractors = [Extractor(label='tech',
-                        group="//table//tr/td[@class='label']",
-                        group_key="./text()",
-                        group_key_normalize=lambda x: x.lower().strip(),
-                        path=".",
-                        attrs=Attribute(key=None,
-                                        path="..//td[2]//text()",
-                                    postprocess=lambda x: [t.strip()
-                                                           for t in x.split(':::') if t.strip()]))]
+    extractors = [
+        Extractor(
+            label='tech',
+            group="//table//tr/td[@class='label']",
+            group_key="./text()",
+            group_key_normalize=lambda x: x.lower().strip(),
+            path=".",
+            attrs=Attribute(
+                key=None,
+                path="..//td[2]//text()",
+                postprocess=lambda x: [t.strip() for t in x.split(':::') if t.strip()]
+            )
+        )
+    ]
 
     preprocessors = [
         (re.compile('(<h5>.*?</h5>)', re.I), r'</div>\1<div class="_imdbpy">'),
-        (re.compile('((<br/>|</p>|</table>))\n?<br/>(?!<a)', re.I),
-            r'\1</div>'),
+        (re.compile('((<br/>|</p>|</table>))\n?<br/>(?!<a)', re.I), r'\1</div>'),
         # the ones below are for the publicity parser
         (re.compile('<p>(.*?)</p>', re.I), r'\1<br/>'),
         (re.compile('(</td><td valign="top">)', re.I), r'\1::'),
         (re.compile('(</tr><tr>)', re.I), r'\n\1'),
         (re.compile('<span class="ghost">\|</span>', re.I), r':::'),
-        (re.compile('<br/?>', re.I), r':::'),
+        (re.compile('<br/?>', re.I), r':::')
         # this is for splitting individual entries
-        ]
+    ]
 
     def postprocess_data(self, data):
         for key in data:
@@ -1384,10 +1703,16 @@ class DOMHTMLBusinessParser(DOMParserBase):
     """
     re_space = re.compile(r'\s+')
 
-    extractors = [Extractor(label='business',
-                    path="//div[@id='tn15content']//h5",
-                    attrs=Attribute(key='./text()',
-                                    path="./following-sibling::div[1]//text()"))]
+    extractors = [
+        Extractor(
+            label='business',
+            path="//div[@id='tn15content']//h5",
+            attrs=Attribute(
+                key='./text()',
+                path="./following-sibling::div[1]//text()"
+            )
+        )
+    ]
 
     preprocessors = [
         ('</h5>', '</h5><div class="_imdbpy">'),
@@ -1395,7 +1720,7 @@ class DOMHTMLBusinessParser(DOMParserBase):
         ('<h5>', '</div><h5>'),
         ('<hr/><h3>', '</div><hr/><h3>'),
         ('<br/>', ':::')
-        ]
+    ]
 
     def postprocess_data(self, data):
         newData = {}
@@ -1421,12 +1746,21 @@ class DOMHTMLRecParser(DOMParserBase):
     """
     _containsObjects = True
 
-    extractors = [Extractor(label='recommendations',
-                    path="//td[@valign='middle'][1]",
-                    attrs=Attribute(key='../../tr/td[1]//text()',
-                            multi=True,
-                            path={'title': ".//text()",
-                                    'movieID': ".//a/@href"}))]
+    extractors = [
+        Extractor(
+            label='recommendations',
+            path="//td[@valign='middle'][1]",
+            attrs=Attribute(
+                key='../../tr/td[1]//text()',
+                multi=True,
+                path={
+                    'title': ".//text()",
+                    'movieID': ".//a/@href"
+                }
+            )
+        )
+    ]
+
     def postprocess_data(self, data):
         for key in data.keys():
             n_key = key
@@ -1435,12 +1769,14 @@ class DOMHTMLRecParser(DOMParserBase):
                 n_key = 'database'
             elif n_keyl == 'imdb users recommend':
                 n_key = 'users'
-            data[n_key] = [Movie(title=x['title'],
-                        movieID=analyze_imdbid(x['movieID']),
-                        accessSystem=self._as, modFunct=self._modFunct)
-                        for x in data[key]]
+            data[n_key] = [
+                Movie(title=x['title'], movieID=analyze_imdbid(x['movieID']),
+                      accessSystem=self._as, modFunct=self._modFunct)
+                for x in data[key]
+            ]
             del data[key]
-        if data: return {'recommendations': data}
+        if data:
+            return {'recommendations': data}
         return data
 
 
@@ -1457,9 +1793,11 @@ class DOMHTMLNewsParser(DOMParserBase):
     _defGetRefs = True
 
     extractors = [
-        Extractor(label='news',
+        Extractor(
+            label='news',
             path="//h2",
-            attrs=Attribute(key='news',
+            attrs=Attribute(
+                key='news',
                 multi=True,
                 path={
                     'title': "./text()",
@@ -1468,25 +1806,25 @@ class DOMHTMLNewsParser(DOMParserBase):
                     #        inside news text.
                     'body': "../following-sibling::p[2]//text()",
                     'link': "../..//a[text()='Permalink']/@href",
-                    'fulllink': "../..//a[starts-with(text(), " \
-                            "'See full article at')]/@href"
-                    },
+                    'fulllink': "../..//a[starts-with(text(), 'See full article at')]/@href"
+                },
                 postprocess=lambda x: {
                     'title': x.get('title').strip(),
                     'date': x.get('fromdate').split('|')[0].strip(),
-                    'from': x.get('fromdate').split('|')[1].replace('From ',
-                            '').strip(),
+                    'from': x.get('fromdate').split('|')[1].replace('From ', '').strip(),
                     'body': (x.get('body') or u'').strip(),
                     'link': _normalize_href(x.get('link')),
                     'full article link': _normalize_href(x.get('fulllink'))
-                }))
-        ]
+                }
+            )
+        )
+    ]
 
     preprocessors = [
         (re.compile('(<a name=[^>]+><h2>)', re.I), r'<div class="_imdbpy">\1'),
         (re.compile('(<hr/>)', re.I), r'</div>\1'),
         (re.compile('<p></p>', re.I), r'')
-        ]
+    ]
 
     def postprocess_data(self, data):
         if not data.has_key('news'):
@@ -1501,11 +1839,13 @@ class DOMHTMLNewsParser(DOMParserBase):
 def _parse_review(x):
     result = {}
     title = x.get('title').strip()
-    if title[-1] == ':': title = title[:-1]
+    if title[-1] == ':':
+        title = title[:-1]
     result['title'] = title
     result['link'] = _normalize_href(x.get('link'))
-    kind =  x.get('kind').strip()
-    if kind[-1] == ':': kind = kind[:-1]
+    kind = x.get('kind').strip()
+    if kind[-1] == ':':
+        kind = kind[:-1]
     result['review kind'] = kind
     text = x.get('review').replace('\n\n', '||').replace('\n', ' ').split('||')
     review = '\n'.join(text)
@@ -1531,86 +1871,115 @@ class DOMHTMLSeasonEpisodesParser(DOMParserBase):
         sparser = DOMHTMLSeasonEpisodesParser()
         result = sparser.parse(episodes_html_string)
     """
+
     extractors = [
-            Extractor(label='series link',
-                path="//div[@class='parent']",
-                attrs=[Attribute(key='series link',
-                            path=".//a/@href")]
-            ),
-
-            Extractor(label='series title',
-                path="//head/meta[@property='og:title']",
-                attrs=[Attribute(key='series title',
-                            path="./@content")]
-            ),
-
-            Extractor(label='seasons list',
-                path="//select[@id='bySeason']//option",
-                attrs=[Attribute(key='_seasons',
-                            multi=True,
-                            path="./@value")]),
-
-            Extractor(label='selected season',
-                path="//select[@id='bySeason']//option[@selected]",
-                attrs=[Attribute(key='_current_season',
-                            path='./@value')]),
-
-            Extractor(label='episodes',
-                path=".",
-                group="//div[@class='info']",
-                group_key=".//meta/@content",
-                group_key_normalize=lambda x: 'episode %s' % x,
-                attrs=[Attribute(key=None,
-                            multi=True,
-                            path={
-                                "link": ".//strong//a[@href][1]/@href",
-                                "original air date": ".//div[@class='airdate']/text()",
-                                "title": ".//strong//text()",
-                                "plot": ".//div[@class='item_description']//text()"
-                            }
-                        )]
+        Extractor(
+            label='series link',
+            path="//div[@class='parent']",
+            attrs=[
+                Attribute(
+                    key='series link',
+                    path=".//a/@href"
                 )
             ]
+        ),
+
+        Extractor(
+            label='series title',
+            path="//head/meta[@property='og:title']",
+            attrs=[
+                Attribute(
+                    key='series title',
+                    path="./@content"
+                )
+            ]
+        ),
+
+        Extractor(
+            label='seasons list',
+            path="//select[@id='bySeason']//option",
+            attrs=[
+                Attribute(
+                    key='_seasons',
+                    multi=True,
+                    path="./@value"
+                )
+            ]
+        ),
+
+        Extractor(
+            label='selected season',
+            path="//select[@id='bySeason']//option[@selected]",
+            attrs=[
+                Attribute(
+                    key='_current_season',
+                    path='./@value'
+                )
+            ]
+        ),
+
+        Extractor(
+            label='episodes',
+            path=".",
+            group="//div[@class='info']",
+            group_key=".//meta/@content",
+            group_key_normalize=lambda x: 'episode %s' % x,
+            attrs=[
+                Attribute(
+                    key=None,
+                    multi=True,
+                    path={
+                        "link": ".//strong//a[@href][1]/@href",
+                        "original air date": ".//div[@class='airdate']/text()",
+                        "title": ".//strong//text()",
+                        "plot": ".//div[@class='item_description']//text()"
+                    }
+                )
+            ]
+        )
+    ]
 
     def postprocess_data(self, data):
         series_id = analyze_imdbid(data.get('series link'))
         series_title = data.get('series title', '').strip()
-        selected_season = data.get('_current_season',
-                                    'unknown season').strip()
+        selected_season = data.get('_current_season', 'unknown season').strip()
         if not (series_id and series_title):
             return {}
         series = Movie(title=series_title, movieID=str(series_id),
-                        accessSystem=self._as, modFunct=self._modFunct)
+                       accessSystem=self._as, modFunct=self._modFunct)
         if series.get('kind') == 'movie':
             series['kind'] = u'tv series'
-        try: selected_season = int(selected_season)
-        except: pass
+        try:
+            selected_season = int(selected_season)
+        except:
+            pass
         nd = {selected_season: {}}
         if 'episode -1' in data:
-          counter = 1
-          for episode in data['episode -1']:
-            while 'episode %d' % counter in data:
-              counter += 1
-            k = 'episode %d' % counter
-            data[k] = [episode]
-          del data['episode -1']
-        for episode_nr, episode in data.iteritems():
+            counter = 1
+            for episode in data['episode -1']:
+                while 'episode %d' % counter in data:
+                    counter += 1
+                k = 'episode %d' % counter
+                data[k] = [episode]
+            del data['episode -1']
+        for episode_nr, episode in data.items():
             if not (episode and episode[0] and
                     episode_nr.startswith('episode ')):
                 continue
             episode = episode[0]
             episode_nr = episode_nr[8:].rstrip()
-            try: episode_nr = int(episode_nr)
-            except: pass
+            try:
+                episode_nr = int(episode_nr)
+            except:
+                pass
             episode_id = analyze_imdbid(episode.get('link' ''))
-            episode_air_date = episode.get('original air date',
-                                            '').strip()
+            episode_air_date = episode.get('original air date', '').strip()
             episode_title = episode.get('title', '').strip()
             episode_plot = episode.get('plot', '')
             if not (episode_nr is not None and episode_id and episode_title):
                 continue
             ep_obj = Movie(movieID=episode_id, title=episode_title,
-                        accessSystem=self._as, modFunct=self._modFunct)
+                           accessSystem=self._as, modFunct=self._modFunct)
             ep_obj['kind'] = u'episode'
             ep_obj['episode of'] = series
             ep_obj['season'] = selected_season
@@ -1624,10 +1993,11 @@ class DOMHTMLSeasonEpisodesParser(DOMParserBase):
             nd[selected_season][episode_nr] = ep_obj
         _seasons = data.get('_seasons') or []
         for idx, season in enumerate(_seasons):
-            try: _seasons[idx] = int(season)
-            except: pass
-        return {'episodes': nd, '_seasons': _seasons,
-                '_current_season': selected_season}
+            try:
+                _seasons[idx] = int(season)
+            except:
+                pass
+        return {'episodes': nd, '_seasons': _seasons, '_current_season': selected_season}
 
 
 def _build_episode(x):
@@ -1642,7 +2012,8 @@ def _build_episode(x):
     year = x.get('year')
     if year is not None:
         year = year[5:]
-        if year == 'unknown': year = u'????'
+        if year == 'unknown':
+            year = u'????'
         if year and year.isdigit():
             year = int(year)
         e['year'] = year
@@ -1683,19 +2054,28 @@ class DOMHTMLEpisodesParser(DOMParserBase):
 
     def _init(self):
         self.extractors = [
-            Extractor(label='series',
+            Extractor(
+                label='series',
                 path="//html",
-                attrs=[Attribute(key='series title',
-                                path=".//title/text()"),
-                        Attribute(key='series movieID',
-                                path=".//h1/a[@class='main']/@href",
-                                postprocess=analyze_imdbid)
-                    ]),
-            Extractor(label='episodes',
+                attrs=[
+                    Attribute(
+                        key='series title',
+                        path=".//title/text()"
+                    ),
+                    Attribute(
+                        key='series movieID',
+                        path=".//h1/a[@class='main']/@href",
+                        postprocess=analyze_imdbid
+                    )
+                ]
+            ),
+            Extractor(
+                label='episodes',
                 group="//div[@class='_imdbpy']/h3",
                 group_key="./a/@name",
                 path=self._episodes_path,
-                attrs=Attribute(key=None,
+                attrs=Attribute(
+                    key=None,
                     multi=True,
                     path={
                         'link': "./a/@href",
@@ -1705,69 +2085,85 @@ class DOMHTMLEpisodesParser(DOMParserBase):
                         'oad': self._oad_path,
                         'plot': "./following-sibling::text()[1]"
                     },
-                    postprocess=_build_episode))]
+                    postprocess=_build_episode
+                )
+            )
+        ]
+
         if self.kind == 'episodes cast':
             self.extractors += [
-                Extractor(label='cast',
+                Extractor(
+                    label='cast',
                     group="//h4",
                     group_key="./text()[1]",
                     group_key_normalize=lambda x: x.strip(),
                     path="./following-sibling::table[1]//td[@class='nm']",
-                    attrs=Attribute(key=None,
+                    attrs=Attribute(
+                        key=None,
                         multi=True,
-                        path={'person': "..//text()",
+                        path={
+                            'person': "..//text()",
                             'link': "./a/@href",
-                            'roleID': \
-                                "../td[4]/div[@class='_imdbpyrole']/@roleid"},
-                        postprocess=lambda x: \
-                                build_person(x.get('person') or u'',
-                                personID=analyze_imdbid(x.get('link')),
-                                roleID=(x.get('roleID') or u'').split('/'),
-                                accessSystem=self._as,
-                                modFunct=self._modFunct)))
-                ]
+                            'roleID': "../td[4]/div[@class='_imdbpyrole']/@roleid"
+                        },
+                        postprocess=lambda x: build_person(
+                            x.get('person') or u'',
+                            personID=analyze_imdbid(x.get('link')),
+                            roleID=(x.get('roleID') or u'').split('/'),
+                            accessSystem=self._as,
+                            modFunct=self._modFunct
+                        )
+                    )
+                )
+            ]
 
     preprocessors = [
-        (re.compile('(<hr/>\n)(<h3>)', re.I),
-                    r'</div>\1<div class="_imdbpy">\2'),
+        (re.compile('(<hr/>\n)(<h3>)', re.I), r'</div>\1<div class="_imdbpy">\2'),
         (re.compile('(</p>\n\n)</div>', re.I), r'\1'),
         (re.compile('<h3>(.*?)</h3>', re.I), r'<h4>\1</h4>'),
         (_reRolesMovie, _manageRoles),
         (re.compile('(<br/> <br/>\n)(<hr/>)', re.I), r'\1</div>\2')
-        ]
+    ]
 
     def postprocess_data(self, data):
         # A bit extreme?
-        if not 'series title' in data: return {}
-        if not 'series movieID' in data: return {}
+        if 'series title' not in data:
+            return {}
+        if 'series movieID' not in data:
+            return {}
         stitle = data['series title'].replace('- Episode list', '')
         stitle = stitle.replace('- Episodes list', '')
         stitle = stitle.replace('- Episode cast', '')
         stitle = stitle.replace('- Episodes cast', '')
         stitle = stitle.strip()
-        if not stitle: return {}
+        if not stitle:
+            return {}
         seriesID = data['series movieID']
-        if seriesID is None: return {}
+        if seriesID is None:
+            return {}
         series = Movie(title=stitle, movieID=str(seriesID),
-                        accessSystem=self._as, modFunct=self._modFunct)
+                       accessSystem=self._as, modFunct=self._modFunct)
         nd = {}
         for key in data.keys():
             if key.startswith('filter-season-') or key.startswith('season-'):
                 season_key = key.replace('filter-season-', '').replace('season-', '')
-                try: season_key = int(season_key)
-                except: pass
+                try:
+                    season_key = int(season_key)
+                except:
+                    pass
                 nd[season_key] = {}
                 ep_counter = 1
                 for episode in data[key]:
-                    if not episode: continue
+                    if not episode:
+                        continue
                     episode_key = episode.get('episode')
-                    if episode_key is None: continue
+                    if episode_key is None:
+                        continue
                     if not isinstance(episode_key, int):
                         episode_key = ep_counter
                         ep_counter += 1
-                    cast_key = 'Season %s, Episode %s:' % (season_key,
-                                                            episode_key)
-                    if data.has_key(cast_key):
+                    cast_key = 'Season %s, Episode %s:' % (season_key, episode_key)
+                    if cast_key in data:
                         cast = data[cast_key]
                         for i in xrange(len(cast)):
                             cast[i].billingPos = i + 1
@@ -1809,25 +2205,30 @@ class DOMHTMLFaqsParser(DOMParserBase):
     # XXX: bsoup and lxml don't match (looks like a minor issue, anyway).
 
     extractors = [
-        Extractor(label='faqs',
+        Extractor(
+            label='faqs',
             path="//div[@class='section']",
-            attrs=Attribute(key='faqs',
+            attrs=Attribute(
+                key='faqs',
                 multi=True,
                 path={
                     'question': "./h3/a/span/text()",
                     'answer': "../following-sibling::div[1]//text()"
                 },
-                postprocess=lambda x: u'%s::%s' % (x.get('question').strip(),
-                                    '\n\n'.join(x.get('answer').replace(
-                                        '\n\n', '\n').strip().split('||')))))
-        ]
+                postprocess=lambda x: u'%s::%s' % (
+                    x.get('question').strip(),
+                    '\n\n'.join(x.get('answer').replace('\n\n', '\n').strip().split('||'))
+                )
+            )
+        )
+    ]
 
     preprocessors = [
         (re.compile('<br/><br/>', re.I), r'||'),
         (re.compile('<h4>(.*?)</h4>\n', re.I), r'||\1--'),
         (re.compile('<span class="spoiler"><span>(.*?)</span></span>', re.I),
          r'[spoiler]\1[/spoiler]')
-        ]
+    ]
 
 
 class DOMHTMLAiringParser(DOMParserBase):
@@ -1843,18 +2244,30 @@ class DOMHTMLAiringParser(DOMParserBase):
     _containsObjects = True
 
     extractors = [
-        Extractor(label='series title',
+        Extractor(
+            label='series title',
             path="//title",
-            attrs=Attribute(key='series title', path="./text()",
-                            postprocess=lambda x: \
-                                    x.replace(' - TV schedule', u''))),
-        Extractor(label='series id',
-            path="//h1/a[@href]",
-            attrs=Attribute(key='series id', path="./@href")),
+            attrs=Attribute(
+                key='series title',
+                path="./text()",
+                postprocess=lambda x: x.replace(' - TV schedule', u'')
+            )
+        ),
 
-        Extractor(label='tv airings',
+        Extractor(
+            label='series id',
+            path="//h1/a[@href]",
+            attrs=Attribute(
+                key='series id',
+                path="./@href"
+            )
+        ),
+
+        Extractor(
+            label='tv airings',
             path="//tr[@class]",
-            attrs=Attribute(key='airing',
+            attrs=Attribute(
+                key='airing',
                 multi=True,
                 path={
                     'date': "./td[1]//text()",
@@ -1863,7 +2276,7 @@ class DOMHTMLAiringParser(DOMParserBase):
                     'link': "./td[4]/a[1]/@href",
                     'title': "./td[4]//text()",
                     'season': "./td[5]//text()",
-                    },
+                },
                 postprocess=lambda x: {
                     'date': x.get('date'),
                     'time': x.get('time'),
@@ -1871,8 +2284,9 @@ class DOMHTMLAiringParser(DOMParserBase):
                     'link': x.get('link'),
                     'title': x.get('title'),
                     'season': (x.get('season') or '').strip()
-                    }
-                ))
+                }
+            )
+        )
     ]
 
     def postprocess_data(self, data):
@@ -1920,16 +2334,20 @@ class DOMHTMLSynopsisParser(DOMParserBase):
         result = sparser.parse(synopsis_html_string)
     """
     extractors = [
-        Extractor(label='synopsis',
+        Extractor(
+            label='synopsis',
             path="//ul[@id='plot-synopsis-content'][not(@style)]",
-            attrs=Attribute(key='synopsis',
+            attrs=Attribute(
+                key='synopsis',
                 path=".//text()",
-                postprocess=lambda x: '\n\n'.join(x.strip().split('||'))))
+                postprocess=lambda x: '\n\n'.join(x.strip().split('||'))
+            )
+        )
     ]
 
     preprocessors = [
         (re.compile('<br/><br/>', re.I), r'||')
-        ]
+    ]
 
 
 class DOMHTMLParentsGuideParser(DOMParserBase):
@@ -1943,20 +2361,25 @@ class DOMHTMLParentsGuideParser(DOMParserBase):
         result = pgparser.parse(parentsguide_html_string)
     """
     extractors = [
-        Extractor(label='parents guide',
+        Extractor(
+            label='parents guide',
             group="//div[@class='section']",
             group_key="./h3/a/span/text()",
             group_key_normalize=lambda x: x.lower(),
             path="../following-sibling::div[1]/p",
-            attrs=Attribute(key=None,
+            attrs=Attribute(
+                key=None,
                 path=".//text()",
-                postprocess=lambda x: [t.strip().replace('\n', ' ')
-                                       for t in x.split('||') if t.strip()]))
+                postprocess=lambda x: [
+                    t.strip().replace('\n', ' ') for t in x.split('||') if t.strip()
+                ]
+            )
+        )
     ]
 
     preprocessors = [
         (re.compile('<br/><br/>', re.I), r'||')
-        ]
+    ]
 
     def postprocess_data(self, data):
         data2 = {}
@@ -1969,49 +2392,39 @@ class DOMHTMLParentsGuideParser(DOMParserBase):
 
 
 _OBJECTS = {
-    'movie_parser':  ((DOMHTMLMovieParser,), None),
-    'plot_parser':  ((DOMHTMLPlotParser,), None),
+    'movie_parser': ((DOMHTMLMovieParser,), None),
+    'plot_parser': ((DOMHTMLPlotParser,), None),
     'movie_awards_parser': ((DOMHTMLAwardsParser,), None),
-    'taglines_parser':  ((DOMHTMLTaglinesParser,), None),
-    'keywords_parser':  ((DOMHTMLKeywordsParser,), None),
-    'crazycredits_parser':  ((DOMHTMLCrazyCreditsParser,), None),
-    'goofs_parser':  ((DOMHTMLGoofsParser,), None),
-    'alternateversions_parser':  ((DOMHTMLAlternateVersionsParser,), None),
-    'trivia_parser':  ((DOMHTMLTriviaParser,), None),
-    'soundtrack_parser':  ((DOMHTMLSoundtrackParser,), None),
-    'quotes_parser':  ((DOMHTMLQuotesParser,), None),
-    'releasedates_parser':  ((DOMHTMLReleaseinfoParser,), None),
-    'ratings_parser':  ((DOMHTMLRatingsParser,), None),
-    'officialsites_parser':  ((DOMHTMLOfficialsitesParser,), None),
-    'criticrev_parser':  ((DOMHTMLCriticReviewsParser,),
-                            {'kind': 'critic reviews'}),
-    'externalrev_parser':  ((DOMHTMLOfficialsitesParser,),
-                            {'kind': 'external reviews'}),
-    'newsgrouprev_parser':  ((DOMHTMLOfficialsitesParser,),
-                            {'kind': 'newsgroup reviews'}),
-    'misclinks_parser':  ((DOMHTMLOfficialsitesParser,),
-                            {'kind': 'misc links'}),
-    'soundclips_parser':  ((DOMHTMLOfficialsitesParser,),
-                            {'kind': 'sound clips'}),
-    'videoclips_parser':  ((DOMHTMLOfficialsitesParser,),
-                            {'kind': 'video clips'}),
-    'photosites_parser':  ((DOMHTMLOfficialsitesParser,),
-                            {'kind': 'photo sites'}),
-    'connections_parser':  ((DOMHTMLConnectionParser,), None),
-    'tech_parser':  ((DOMHTMLTechParser,), None),
-    'business_parser':  ((DOMHTMLBusinessParser,),
-                            {'kind': 'business', '_defGetRefs': 1}),
-    'literature_parser':  ((DOMHTMLBusinessParser,), None),
-    'locations_parser':  ((DOMHTMLLocationsParser,), None),
-    'rec_parser':  ((DOMHTMLRecParser,), None),
-    'news_parser':  ((DOMHTMLNewsParser,), None),
-    'episodes_parser':  ((DOMHTMLEpisodesParser,), None),
-    'season_episodes_parser':  ((DOMHTMLSeasonEpisodesParser,), None),
-    'episodes_cast_parser':  ((DOMHTMLEpisodesCastParser,), None),
-    'eprating_parser':  ((DOMHTMLEpisodesRatings,), None),
-    'movie_faqs_parser':  ((DOMHTMLFaqsParser,), None),
-    'airing_parser':  ((DOMHTMLAiringParser,), None),
-    'synopsis_parser':  ((DOMHTMLSynopsisParser,), None),
-    'parentsguide_parser':  ((DOMHTMLParentsGuideParser,), None)
+    'taglines_parser': ((DOMHTMLTaglinesParser,), None),
+    'keywords_parser': ((DOMHTMLKeywordsParser,), None),
+    'crazycredits_parser': ((DOMHTMLCrazyCreditsParser,), None),
+    'goofs_parser': ((DOMHTMLGoofsParser,), None),
+    'alternateversions_parser': ((DOMHTMLAlternateVersionsParser,), None),
+    'trivia_parser': ((DOMHTMLTriviaParser,), None),
+    'soundtrack_parser': ((DOMHTMLSoundtrackParser,), None),
+    'quotes_parser': ((DOMHTMLQuotesParser,), None),
+    'releasedates_parser': ((DOMHTMLReleaseinfoParser,), None),
+    'ratings_parser': ((DOMHTMLRatingsParser,), None),
+    'officialsites_parser': ((DOMHTMLOfficialsitesParser,), None),
+    'criticrev_parser': ((DOMHTMLCriticReviewsParser,), {'kind': 'critic reviews'}),
+    'externalrev_parser': ((DOMHTMLOfficialsitesParser,), {'kind': 'external reviews'}),
+    'misclinks_parser': ((DOMHTMLOfficialsitesParser,), {'kind': 'misc links'}),
+    'soundclips_parser': ((DOMHTMLOfficialsitesParser,), {'kind': 'sound clips'}),
+    'videoclips_parser': ((DOMHTMLOfficialsitesParser,), {'kind': 'video clips'}),
+    'photosites_parser': ((DOMHTMLOfficialsitesParser,), {'kind': 'photo sites'}),
+    'connections_parser': ((DOMHTMLConnectionParser,), None),
+    'tech_parser': ((DOMHTMLTechParser,), None),
+    'business_parser': ((DOMHTMLBusinessParser,), {'kind': 'business', '_defGetRefs': 1}),
+    'literature_parser': ((DOMHTMLBusinessParser,), None),
+    'locations_parser': ((DOMHTMLLocationsParser,), None),
+    'rec_parser': ((DOMHTMLRecParser,), None),
+    'news_parser': ((DOMHTMLNewsParser,), None),
+    'episodes_parser': ((DOMHTMLEpisodesParser,), None),
+    'season_episodes_parser': ((DOMHTMLSeasonEpisodesParser,), None),
+    'episodes_cast_parser': ((DOMHTMLEpisodesCastParser,), None),
+    'eprating_parser': ((DOMHTMLEpisodesRatings,), None),
+    'movie_faqs_parser': ((DOMHTMLFaqsParser,), None),
+    'airing_parser': ((DOMHTMLAiringParser,), None),
+    'synopsis_parser': ((DOMHTMLSynopsisParser,), None),
+    'parentsguide_parser': ((DOMHTMLParentsGuideParser,), None)
 }
-

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -34,7 +34,7 @@ from imdb import imdbURL_base
 from imdb.Company import Company
 from imdb.Movie import Movie
 from imdb.Person import Person
-from imdb.utils import _Container, analyze_title
+from imdb.utils import _Container, KIND_MAP
 
 from .utils import Attribute, DOMParserBase, Extractor, analyze_imdbid, build_person
 
@@ -167,19 +167,15 @@ def analyze_og_title(og_title):
         data['year'] = int(match.group(5))
         kind = match.group(3)
         if kind is None:
-            kind = 'Movie'
+            kind = 'movie'
         else:
-            if kind == 'TV Episode':
-                kind = 'Episode'
-            elif kind == 'TV Mini-Series':
-                kind = 'TV Mini Series'
-            elif kind == 'Video':
-                kind = 'Video Movie'
-        data['kind'] = kind.lower()
+            kind = kind.lower()
+            kind = KIND_MAP.get(kind, kind)
+        data['kind'] = kind
         years = match.group(6)
         if years is not None:
             data['series years'] = match.group(4).strip()
-        elif kind.endswith('Series'):
+        elif kind.endswith('series'):
             data['series years'] = '%(year)d-%(year)d' % {'year': data['year']}
     return data
 

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -172,10 +172,10 @@ class DOMHTMLMovieParser(DOMParserBase):
     extractors = [
         Extractor(
             label='title',
-            path="//h3[@itemprop='name']",
+            path="//meta[@property='og:title']",
             attrs=Attribute(
                 key='title',
-                path=".//text()",
+                path="@content",
                 postprocess=analyze_title
             )
         ),

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -159,7 +159,7 @@ def _toInt(val, replace=()):
 
 
 _re_og_title = re.compile(
-    ur'(.*) \((?:(.+)(?= ))? ?(\d{4})(?:–(\d{4}| ))?\)',
+    ur'(.*) \((?:(.+)(?= ))? ?(\d{4})(?:(–)(\d{4}| ))?\)',
     re.UNICODE
 )
 
@@ -177,11 +177,22 @@ def analyze_og_title(og_title):
             kind = kind.lower()
             kind = KIND_MAP.get(kind, kind)
         data['kind'] = kind
-        years = match.group(4)
-        if years is not None:
-            data['series years'] = years.strip()
+
+        year_separator = match.group(4)
+        # There is a year separator so assume an ongoing or ended series
+        if year_separator is not None:
+            end_year = match.group(5)
+            if end_year is not None:
+                data['series years'] = '%(year)d-%(end_year)s' % {
+                    'year': data['year'],
+                    'end_year': end_year.strip(),
+                }
+            elif kind.endswith('series'):
+                data['series years'] = '%(year)d-' % {'year': data['year']}
+        # No year separator and series, so assume that it ended the same year
         elif kind.endswith('series'):
             data['series years'] = '%(year)d-%(year)d' % {'year': data['year']}
+
     return data
 
 

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -11,7 +11,7 @@ pages would be:
     plot summary:       http://www.imdb.com/title/tt0094226/plotsummary
     ...and so on...
 
-Copyright 2004-2017 Davide Alberani <da@erlug.linux.it>
+Copyright 2004-2018 Davide Alberani <da@erlug.linux.it>
           2008-2018 H. Turgut Uyar <uyar@tekir.org>
 
 This program is free software; you can redistribute it and/or modify
@@ -270,7 +270,7 @@ class DOMHTMLMovieParser(DOMParserBase):
 
         Extractor(
             label='cast',
-            path="//table[@class='cast']//tr",
+            path="//table[@class='cast_list']//tr",
             attrs=Attribute(
                 key="cast",
                 multi=True,

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -12,7 +12,7 @@ pages would be:
     ...and so on...
 
 Copyright 2004-2017 Davide Alberani <da@erlug.linux.it>
-               2008 H. Turgut Uyar <uyar@tekir.org>
+          2008-2018 H. Turgut Uyar <uyar@tekir.org>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -195,6 +195,7 @@ def analyze_og_title(og_title):
 
         if data['kind'] == 'episode' and data['title'][0] == '"':
             quote_end = data['title'].find('"', 1)
+            data['tv series title'] = data['title'][1:quote_end]
             data['title'] = data['title'][quote_end + 1:].strip()
 
     return data
@@ -401,17 +402,10 @@ class DOMHTMLMovieParser(DOMParserBase):
                 Attribute(
                     key='original air date',
                     path=".//td[starts-with(text(), 'Original Air Date')]/../div/text()"
-                ),
-                Attribute(
-                    key='tv series link',
-                    path=".//td[starts-with(text(), 'TV Series')]/..//a/@href"
-                ),
-                Attribute(
-                    key='tv series title',
-                    path=".//td[starts-with(text(), 'TV Series')]/..//a/text()"
                 )
             ]
         ),
+
 
         Extractor(
             label='creator',
@@ -522,6 +516,15 @@ class DOMHTMLMovieParser(DOMParserBase):
                 key='next episode',
                 path="./@href",
                 postprocess=lambda x: analyze_imdbid(x)
+            )
+        ),
+
+        Extractor(
+            label='tv series link',
+            path=".//a[starts-with(text(), 'All Episodes')]",
+            attrs=Attribute(
+                key='tv series link',
+                path="./@href"
             )
         ),
 
@@ -752,6 +755,7 @@ class DOMHTMLMovieParser(DOMParserBase):
                                            movieID=analyze_imdbid(data['tv series link']),
                                            accessSystem=self._as,
                                            modFunct=self._modFunct)
+                data['episode of']['kind'] = 'tv series'
                 del data['tv series title']
             del data['tv series link']
         if 'rating' in data:

--- a/imdb/parser/http/personParser.py
+++ b/imdb/parser/http/personParser.py
@@ -465,7 +465,7 @@ def _build_episode(link, title, minfo, role, roleA, roleAID):
     minidx = minfo.find(' -')
     # Sometimes, for some unknown reason, the role is left in minfo.
     if minidx != -1:
-        slfRole = minfo[minidx+3:].lstrip()
+        slfRole = minfo[minidx + 3:].lstrip()
         minfo = minfo[:minidx].rstrip()
         if slfRole.endswith(')'):
             commidx = slfRole.rfind('(')

--- a/imdb/parser/http/personParser.py
+++ b/imdb/parser/http/personParser.py
@@ -225,92 +225,157 @@ class DOMHTMLBioParser(DOMParserBase):
                         # TODO: check if this slicing is always correct
                         postprocess=lambda x: u''.join(x).strip()[2:])]
     extractors = [
-            Extractor(label='headshot',
-                        path="//a[@name='headshot']",
-                        attrs=Attribute(key='headshot',
-                            path="./img/@src")),
-            Extractor(label='birth info',
-                        path="//table[@id='overviewTable']//td[text()='Date of Birth']/following-sibling::td[1]",
-                        attrs=_birth_attrs),
-            Extractor(label='death info',
-                        path="//table[@id='overviewTable']//td[text()='Date of Death']/following-sibling::td[1]",
-                        attrs=_death_attrs),
-            Extractor(label='nick names',
-                        path="//table[@id='overviewTable']//td[text()='Nickenames']/following-sibling::td[1]",
-                        attrs=Attribute(key='nick names',
-                            path="./text()",
-                            joiner='|',
-                            postprocess=lambda x: [n.strip().replace(' (',
-                                    '::(', 1) for n in x.split('|')
-                                    if n.strip()])),
-            Extractor(label='birth name',
-                        path="//table[@id='overviewTable']//td[text()='Birth Name']/following-sibling::td[1]",
-                        attrs=Attribute(key='birth name',
-                            path="./text()",
-                            postprocess=lambda x: canonicalName(x.strip()))),
-            Extractor(label='height',
-                path="//table[@id='overviewTable']//td[text()='Height']/following-sibling::td[1]",
-                        attrs=Attribute(key='height',
-                            path="./text()",
-                            postprocess=lambda x: x.strip())),
-            Extractor(label='mini biography',
-                        path="//a[@name='mini_bio']/following-sibling::div[1 = count(preceding-sibling::a[1] | ../a[@name='mini_bio'])]",
-                        attrs=Attribute(key='mini biography',
-                            multi=True,
-                            path={
-                                'bio': ".//text()",
-                                'by': ".//a[@name='ba']//text()"
-                                },
-                            postprocess=lambda x: "%s::%s" % \
-                                ((x.get('bio') or u'').split('- IMDb Mini Biography By:')[0].strip(),
-                                (x.get('by') or u'').strip() or u'Anonymous'))),
-            Extractor(label='spouse',
-                        path="//div[h5='Spouse']/table/tr",
-                        attrs=Attribute(key='spouse',
-                            multi=True,
-                            path={
-                                'name': "./td[1]//text()",
-                                'info': "./td[2]//text()"
-                                },
-                            postprocess=lambda x: ("%s::%s" % \
-                                (x.get('name').strip(),
-                                (x.get('info') or u'').strip())).strip(':'))),
-            Extractor(label='trade mark',
-                        path="//div[h5='Trade Mark']/p",
-                        attrs=Attribute(key='trade mark',
-                            multi=True,
-                            path=".//text()",
-                            postprocess=lambda x: x.strip())),
-            Extractor(label='trivia',
-                        path="//div[h5='Trivia']/p",
-                        attrs=Attribute(key='trivia',
-                            multi=True,
-                            path=".//text()",
-                            postprocess=lambda x: x.strip())),
-            Extractor(label='quotes',
-                        path="//div[h5='Personal Quotes']/p",
-                        attrs=Attribute(key='quotes',
-                            multi=True,
-                            path=".//text()",
-                            postprocess=lambda x: x.strip())),
-            Extractor(label='salary',
-                        path="//div[h5='Salary']/table/tr",
-                        attrs=Attribute(key='salary history',
-                            multi=True,
-                            path={
-                                'title': "./td[1]//text()",
-                                'info': "./td[2]/text()",
-                                },
-                            postprocess=lambda x: "%s::%s" % \
-                                    (x.get('title').strip(),
-                                        x.get('info').strip()))),
-            Extractor(label='where now',
-                        path="//div[h5='Where Are They Now']/p",
-                        attrs=Attribute(key='where now',
-                            multi=True,
-                            path=".//text()",
-                            postprocess=lambda x: x.strip())),
-            ]
+        Extractor(
+            label='headshot',
+            path="//a[@name='headshot']",
+            attrs=Attribute(
+                key='headshot',
+                path="./img/@src"
+            )
+        ),
+
+        Extractor(
+            label='birth info',
+            path="//table[@id='overviewTable']"
+                 "//td[text()='Date of Birth']/following-sibling::td[1]",
+            attrs=_birth_attrs
+        ),
+
+        Extractor(
+            label='death info',
+            path="//table[@id='overviewTable']"
+                 "//td[text()='Date of Death']/following-sibling::td[1]",
+            attrs=_death_attrs
+        ),
+
+        Extractor(
+            label='nick names',
+            path="//table[@id='overviewTable']"
+                 "//td[text()='Nickenames']/following-sibling::td[1]",
+            attrs=Attribute(
+                key='nick names',
+                path="./text()",
+                joiner='|',
+                postprocess=lambda x: [n.strip().replace(' (', '::(', 1) for n in x.split('|')
+                                       if n.strip()]
+            )
+        ),
+
+        Extractor(
+            label='birth name',
+            path="//table[@id='overviewTable']"
+                 "//td[text()='Birth Name']/following-sibling::td[1]",
+            attrs=Attribute(
+                key='birth name',
+                path="./text()",
+                postprocess=lambda x: canonicalName(x.strip())
+            )
+        ),
+
+        Extractor(
+            label='height',
+            path="//table[@id='overviewTable']//td[text()='Height']/following-sibling::td[1]",
+            attrs=Attribute(
+                key='height',
+                path="./text()",
+                postprocess=lambda x: x.strip()
+            )
+        ),
+
+        Extractor(
+            label='mini biography',
+            path="//a[@name='mini_bio']/following-sibling::"
+                 "div[1 = count(preceding-sibling::a[1] | ../a[@name='mini_bio'])]",
+            attrs=Attribute(
+                key='mini biography',
+                multi=True,
+                path={
+                    'bio': ".//text()",
+                    'by': ".//a[@name='ba']//text()"
+                },
+                postprocess=lambda x: "%s::%s" % (
+                    (x.get('bio') or u'').split('- IMDb Mini Biography By:')[0].strip(),
+                    (x.get('by') or u'').strip() or u'Anonymous'
+                )
+            )
+        ),
+
+        Extractor(
+            label='spouse',
+            path="//div[h5='Spouse']/table/tr",
+            attrs=Attribute(
+                key='spouse',
+                multi=True,
+                path={
+                    'name': "./td[1]//text()",
+                    'info': "./td[2]//text()"
+                },
+                postprocess=lambda x: ("%s::%s" % (
+                    x.get('name').strip(),
+                    (x.get('info') or u'').strip())).strip(':')
+            )
+        ),
+
+        Extractor(
+            label='trade mark',
+            path="//div[h5='Trade Mark']/p",
+            attrs=Attribute(
+                key='trade mark',
+                multi=True,
+                path=".//text()",
+                postprocess=lambda x: x.strip()
+            )
+        ),
+
+        Extractor(
+            label='trivia',
+            path="//div[h5='Trivia']/p",
+            attrs=Attribute(
+                key='trivia',
+                multi=True,
+                path=".//text()",
+                postprocess=lambda x: x.strip()
+            )
+        ),
+
+        Extractor(
+            label='quotes',
+            path="//div[h5='Personal Quotes']/p",
+            attrs=Attribute(
+                key='quotes',
+                multi=True,
+                path=".//text()",
+                postprocess=lambda x: x.strip()
+            )
+        ),
+
+        Extractor(
+            label='salary',
+            path="//div[h5='Salary']/table/tr",
+            attrs=Attribute(
+                key='salary history',
+                multi=True,
+                path={
+                    'title': "./td[1]//text()",
+                    'info': "./td[2]/text()",
+                },
+                postprocess=lambda x: "%s::%s" % (
+                    x.get('title').strip(),
+                    x.get('info').strip())
+            )
+        ),
+
+        Extractor(
+            label='where now',
+            path="//div[h5='Where Are They Now']/p",
+            attrs=Attribute(
+                key='where now',
+                multi=True,
+                path=".//text()",
+                postprocess=lambda x: x.strip()
+            )
+        )
+    ]
 
     preprocessors = [
         (re.compile('(<h5>)', re.I), r'</div><div class="_imdbpy">\1'),

--- a/imdb/parser/http/personParser.py
+++ b/imdb/parser/http/personParser.py
@@ -2,10 +2,10 @@
 parser.http.personParser module (imdb package).
 
 This module provides the classes (and the instances), used to parse
-the IMDb pages on the akas.imdb.com server about a person.
+the IMDb pages on the www.imdb.com server about a person.
 E.g., for "Mel Gibson" the referred pages would be:
-    categorized:    http://akas.imdb.com/name/nm0000154/maindetails
-    biography:      http://akas.imdb.com/name/nm0000154/bio
+    categorized:    http://www.imdb.com/name/nm0000154/maindetails
+    biography:      http://www.imdb.com/name/nm0000154/bio
     ...and so on...
 
 Copyright 2004-2013 Davide Alberani <da@erlug.linux.it>
@@ -52,7 +52,7 @@ def build_date(date):
 class DOMHTMLMaindetailsParser(DOMParserBase):
     """Parser for the "categorized" (maindetails) page of a given person.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -192,7 +192,7 @@ class DOMHTMLMaindetailsParser(DOMParserBase):
 class DOMHTMLBioParser(DOMParserBase):
     """Parser for the "biography" page of a given person.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -394,7 +394,7 @@ class DOMHTMLBioParser(DOMParserBase):
 class DOMHTMLResumeParser(DOMParserBase):
     """Parser for the "resume" page of a given person.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -494,7 +494,7 @@ class DOMHTMLResumeParser(DOMParserBase):
 class DOMHTMLOtherWorksParser(DOMParserBase):
     """Parser for the "other works" and "agent" pages of a given person.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -568,7 +568,7 @@ def _build_episode(link, title, minfo, role, roleA, roleAID):
 class DOMHTMLSeriesParser(DOMParserBase):
     """Parser for the "by TV series" page of a given person.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -623,7 +623,7 @@ class DOMHTMLSeriesParser(DOMParserBase):
 class DOMHTMLPersonGenresParser(DOMParserBase):
     """Parser for the "by genre" and "by keywords" pages of a given person.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:

--- a/imdb/parser/http/searchCharacterParser.py
+++ b/imdb/parser/http/searchCharacterParser.py
@@ -5,7 +5,7 @@ This module provides the HTMLSearchCharacterParser class (and the
 search_character_parser instance), used to parse the results of a search
 for a given character.
 E.g., when searching for the name "Jesse James", the parsed page would be:
-    http://akas.imdb.com/find?s=ch;mx=20;q=Jesse+James
+    http://www.imdb.com/find?s=ch;mx=20;q=Jesse+James
 
 Copyright 2007-2012 Davide Alberani <da@erlug.linux.it>
                2008 H. Turgut Uyar <uyar@tekir.org>

--- a/imdb/parser/http/searchCompanyParser.py
+++ b/imdb/parser/http/searchCompanyParser.py
@@ -46,22 +46,29 @@ class DOMHTMLSearchCompanyParser(DOMHTMLSearchMovieParser):
     _titleBuilder = lambda self, x: build_company_name(x)
     _linkPrefix = '/company/co'
 
-    _attrs = [Attribute(key='data',
-                        multi=True,
-                        path={
-                            'link': "./a[1]/@href",
-                            'name': "./a[1]/text()",
-                            'notes': "./text()[1]"
-                            },
-                        postprocess=lambda x: (
-                            analyze_imdbid(x.get('link')),
-                            analyze_company_name(x.get('name')+(x.get('notes')
-                                                or u''), stripNotes=True)
-                        ))]
-    extractors = [Extractor(label='search',
-                            path="//td[@class='result_text']/a[starts-with(@href, " \
-                                    "'/company/co')]/..",
-                            attrs=_attrs)]
+    _attrs = [
+        Attribute(
+            key='data',
+            multi=True,
+            path={
+                'link': "./a[1]/@href",
+                'name': "./a[1]/text()",
+                'notes': "./text()[1]"
+            },
+            postprocess=lambda x: (
+                analyze_imdbid(x.get('link')),
+                analyze_company_name(x.get('name') + (x.get('notes') or u''), stripNotes=True)
+            )
+        )
+    ]
+
+    extractors = [
+        Extractor(
+            label='search',
+            path="//td[@class='result_text']/a[starts-with(@href, '/company/co')]/..",
+            attrs=_attrs
+        )
+    ]
 
 
 _OBJECTS = {

--- a/imdb/parser/http/searchCompanyParser.py
+++ b/imdb/parser/http/searchCompanyParser.py
@@ -5,7 +5,7 @@ This module provides the HTMLSearchCompanyParser class (and the
 search_company_parser instance), used to parse the results of a search
 for a given company.
 E.g., when searching for the name "Columbia Pictures", the parsed page would be:
-    http://akas.imdb.com/find?s=co;mx=20;q=Columbia+Pictures
+    http://www.imdb.com/find?s=co;mx=20;q=Columbia+Pictures
 
 Copyright 2008-2012 Davide Alberani <da@erlug.linux.it>
           2008 H. Turgut Uyar <uyar@tekir.org>

--- a/imdb/parser/http/searchKeywordParser.py
+++ b/imdb/parser/http/searchKeywordParser.py
@@ -5,7 +5,7 @@ This module provides the HTMLSearchKeywordParser class (and the
 search_company_parser instance), used to parse the results of a search
 for a given keyword.
 E.g., when searching for the keyword "alabama", the parsed page would be:
-    http://akas.imdb.com/find?s=kw;mx=20;q=alabama
+    http://www.imdb.com/find?s=kw;mx=20;q=alabama
 
 Copyright 2009 Davide Alberani <da@erlug.linux.it>
 

--- a/imdb/parser/http/searchMovieParser.py
+++ b/imdb/parser/http/searchMovieParser.py
@@ -6,7 +6,7 @@ search_movie_parser instance), used to parse the results of a search
 for a given title.
 E.g., for when searching for the title "the passion", the parsed
 page would be:
-    http://akas.imdb.com/find?q=the+passion&tt=on&mx=20
+    http://www.imdb.com/find?q=the+passion&tt=on&mx=20
 
 Copyright 2004-2013 Davide Alberani <da@erlug.linux.it>
                2008 H. Turgut Uyar <uyar@tekir.org>

--- a/imdb/parser/http/searchPersonParser.py
+++ b/imdb/parser/http/searchPersonParser.py
@@ -5,7 +5,7 @@ This module provides the HTMLSearchPersonParser class (and the
 search_person_parser instance), used to parse the results of a search
 for a given person.
 E.g., when searching for the name "Mel Gibson", the parsed page would be:
-    http://akas.imdb.com/find?q=Mel+Gibson&nm=on&mx=20
+    http://www.imdb.com/find?q=Mel+Gibson&nm=on&mx=20
 
 Copyright 2004-2013 Davide Alberani <da@erlug.linux.it>
                2008 H. Turgut Uyar <uyar@tekir.org>

--- a/imdb/parser/http/topBottomParser.py
+++ b/imdb/parser/http/topBottomParser.py
@@ -42,17 +42,24 @@ class DOMHTMLTop250Parser(DOMParserBase):
     ranktext = 'top 250 rank'
 
     def _init(self):
-        self.extractors = [Extractor(label=self.label,
-                        path="//div[@id='main']//div[1]//div//table//tbody//tr",
-                        attrs=Attribute(key=None,
-                                multi=True,
-                                path={self.ranktext: "./td[2]//text()",
-                                        'rating': "./td[3]//strong//text()",
-                                        'title': "./td[2]//a//text()",
-                                        'year': "./td[2]//span//text()",
-                                        'movieID': "./td[2]//a/@href",
-                                        'votes': "./td[3]//strong/@title"
-                                        }))]
+        self.extractors = [
+            Extractor(
+                label=self.label,
+                path="//div[@id='main']//div[1]//div//table//tbody//tr",
+                attrs=Attribute(
+                    key=None,
+                    multi=True,
+                    path={
+                        self.ranktext: "./td[2]/text()",
+                        'rating': "./td[3]//strong//text()",
+                        'title': "./td[2]//a//text()",
+                        'year': "./td[2]//span//text()",
+                        'movieID': "./td[2]//a/@href",
+                        'votes': "./td[3]//strong/@title"
+                    }
+                )
+            )
+        ]
 
     def postprocess_data(self, data):
         if not data or self.label not in data:

--- a/imdb/parser/http/topBottomParser.py
+++ b/imdb/parser/http/topBottomParser.py
@@ -4,8 +4,8 @@ parser.http.topBottomParser module (imdb package).
 This module provides the classes (and the instances), used to parse the
 lists of top 250 and bottom 100 movies.
 E.g.:
-    http://akas.imdb.com/chart/top
-    http://akas.imdb.com/chart/bottom
+    http://www.imdb.com/chart/top
+    http://www.imdb.com/chart/bottom
 
 Copyright 2009-2015 Davide Alberani <da@erlug.linux.it>
 
@@ -31,7 +31,7 @@ from utils import DOMParserBase, Attribute, Extractor, analyze_imdbid
 class DOMHTMLTop250Parser(DOMParserBase):
     """Parser for the "top 250" page.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:
@@ -102,7 +102,7 @@ class DOMHTMLTop250Parser(DOMParserBase):
 class DOMHTMLBottom100Parser(DOMHTMLTop250Parser):
     """Parser for the "bottom 100" page.
     The page should be provided as a string, as taken from
-    the akas.imdb.com server.  The final result will be a
+    the www.imdb.com server.  The final result will be a
     dictionary, with a key for every relevant section.
 
     Example:

--- a/imdb/parser/http/topBottomParser.py
+++ b/imdb/parser/http/topBottomParser.py
@@ -73,9 +73,11 @@ class DOMHTMLTop250Parser(DOMParserBase):
             if theID in seenIDs:
                 continue
             seenIDs.append(theID)
-            minfo = analyze_title(d['title']+" "+d['year'])
-            try: minfo[self.ranktext] = int(d[self.ranktext].replace('.', ''))
-            except: pass
+            minfo = analyze_title(d['title'] + ' ' + d['year'])
+            try:
+                minfo[self.ranktext] = int(d[self.ranktext].replace('.', ''))
+            except:
+                pass
             if 'votes' in d:
                 try:
                     votes = d['votes'].replace(' votes','')

--- a/imdb/parser/http/utils.py
+++ b/imdb/parser/http/utils.py
@@ -614,6 +614,7 @@ class DOMParserBase(object):
             return html_string
         # Remove silly &nbsp;&raquo; and &ndash; chars.
         html_string = html_string.replace(u' \xbb', u'')
+        html_string = html_string.replace(u'–', u'-')
         html_string = html_string.replace(u'&ndash;', u'-')
         try:
             preprocessors = self.preprocessors

--- a/imdb/parser/http/utils.py
+++ b/imdb/parser/http/utils.py
@@ -787,10 +787,10 @@ class Extractor(object):
 
     def __repr__(self):
         """String representation of an Extractor object."""
-        r = '<Extractor id:%s (label=%s, path=%s, attrs=%s, group=%s, ' \
-                'group_key=%s group_key_normalize=%s)>' % (id(self),
-                        self.label, self.path, repr(self.attrs), self.group,
-                        self.group_key, self.group_key_normalize)
+        t = '<Extractor id:%s (label=%s, path=%s, attrs=%s, group=%s, group_key=%s' + \
+            ', group_key_normalize=%s)>'
+        r = t % (id(self), self.label, self.path, repr(self.attrs), self.group,
+                 self.group_key, self.group_key_normalize)
         return r
 
 

--- a/imdb/parser/http/utils.py
+++ b/imdb/parser/http/utils.py
@@ -614,7 +614,6 @@ class DOMParserBase(object):
             return html_string
         # Remove silly &nbsp;&raquo; and &ndash; chars.
         html_string = html_string.replace(u' \xbb', u'')
-        html_string = html_string.replace(u'–', u'-')
         html_string = html_string.replace(u'&ndash;', u'-')
         try:
             preprocessors = self.preprocessors

--- a/imdb/parser/http/utils.py
+++ b/imdb/parser/http/utils.py
@@ -35,7 +35,9 @@ from imdb.Character import Character
 
 
 # Year, imdbIndex and kind.
-re_yearKind_index = re.compile(r'(\([0-9\?]{4}(?:/[IVXLCDM]+)?\)(?: \(mini\)| \(TV\)| \(V\)| \(VG\))?)')
+re_yearKind_index = re.compile(
+    r'(\([0-9\?]{4}(?:/[IVXLCDM]+)?\)(?: \(mini\)| \(TV\)| \(V\)| \(VG\))?)'
+)
 
 # Match imdb ids in href tags
 re_imdbid = re.compile(r'(title/tt|name/nm|character/ch|company/co)([0-9]+)')
@@ -304,7 +306,7 @@ def build_movie(txt, movieID=None, roleID=None, status=None,
     elif title[-14:] == 'TV mini-series':
         title = title[:-14] + ' (mini)'
     if title and title.endswith(_defSep.rstrip()):
-        title = title[:-len(_defSep)+1]
+        title = title[:-len(_defSep) + 1]
     # Try to understand where the movie title ends.
     while True:
         if year:
@@ -320,18 +322,17 @@ def build_movie(txt, movieID=None, roleID=None, status=None,
         # Try to match paired parentheses; yes: sometimes there are
         # parentheses inside comments...
         nidx = title.rfind('(')
-        while (nidx != -1 and \
-                    title[nidx:].count('(') != title[nidx:].count(')')):
+        while nidx != -1 and title[nidx:].count('(') != title[nidx:].count(')'):
             nidx = title[:nidx].rfind('(')
         # Unbalanced parentheses: stop here.
         if nidx == -1: break
         # The last item in parentheses seems to be a year: stop here.
-        first4 = title[nidx+1:nidx+5]
-        if (first4.isdigit() or first4 == '????') and \
-                title[nidx+5:nidx+6] in (')', '/'): break
+        first4 = title[nidx + 1:nidx + 5]
+        if (first4.isdigit() or first4 == '????') and title[nidx + 5:nidx + 6] in (')', '/'):
+            break
         # The last item in parentheses is a known kind: stop here.
-        if title[nidx+1:-1] in ('TV', 'V', 'mini', 'VG', 'TV movie',
-                'TV series', 'short'): break
+        if title[nidx + 1:-1] in ('TV', 'V', 'mini', 'VG', 'TV movie', 'TV series', 'short'):
+            break
         # Else, in parentheses there are some notes.
         # XXX: should the notes in the role half be kept separated
         #      from the notes in the movie title half?
@@ -471,8 +472,8 @@ class DOMParserBase(object):
                 if _gotError:
                     warnings.warn('falling back to "%s"' % mod)
                 break
-            except ImportError, e:
-                if idx+1 >= nrMods:
+            except ImportError as e:
+                if idx + 1 >= nrMods:
                     # Raise the exception, if we don't have any more
                     # options to try.
                     raise IMDbError('unable to use any parser in %s: %s' % \

--- a/imdb/utils.py
+++ b/imdb/utils.py
@@ -55,7 +55,8 @@ KIND_MAP = {
     'v': 'video movie',
     'video': 'video movie',
     'vg': 'video game',
-    'mini': 'tv mini series'
+    'mini': 'tv mini series',
+    'tv mini-series': 'tv mini series'
 }
 
 # Match only the imdbIndex (for name strings).

--- a/imdb/utils.py
+++ b/imdb/utils.py
@@ -1232,8 +1232,8 @@ class _Container(object):
             self.__role = role
 
     currentRole = property(_get_currentRole, _set_currentRole,
-                            doc="The role of a Person in a Movie" + \
-                            " or the interpreter of a Character in a Movie.")
+                           doc="The role of a Person in a Movie"
+                               " or the interpreter of a Character in a Movie.")
 
     def _init(self, **kwds): pass
 
@@ -1446,10 +1446,10 @@ class _Container(object):
             except RuntimeError, e:
                 # Symbian/python 2.2 has a poor regexp implementation.
                 import warnings
-                warnings.warn('RuntimeError in '
-                        "imdb.utils._Container.__getitem__; if it's not "
-                        "a recursion limit exceeded and we're not running "
-                        "in a Symbian environment, it's a bug:\n%s" % e)
+                warnings.warn("RuntimeError in imdb.utils._Container.__getitem__;"
+                              " if it's not a recursion limit exceeded and we're"
+                              " not running in a Symbian environment, it's a"
+                              " bug:\n%s" % e)
         return rawData
 
     def __setitem__(self, key, item):


### PR DESCRIPTION
I've backported IMDb redesign patches from #103 to legacy branch.

# Steps taken
  1. Identify beginning of the patches
  2. Used `git rev-list --reverse <commit_id>..master -- imdb/parser/http | git cherry-pick --stdin`
  3. In first commit I saw very large conflicts
  4. Searched for PEP8 related commits
  5. Cherry-picked PEP8 related commits
  6. Redone the second step
  7. When looking at conflicts, I've taken extra care at `u` prefixes and `str/unicode` functions
  8. Any special change I have documented in commit message

Hope this helps to anyone. But since, the legacy branch does not have any tests, this patch is likely going to be a cowboy ride on production :).

I've also decided to cherry-pick every commit as-is for easier review (if I've missed something solving the conflicts).