### PR TITLE
Fix movieParser post processing of release dates - KeyError: %s if notes key is missing

### DIFF
--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -1385,7 +1385,7 @@ class DOMHTMLReleaseinfoParser(DOMParserBase):
             date = date.strip()
             if not (country and date):
                 continue
-            notes = i['notes']
+            notes = i.get('notes')
             info = '%s::%s' % (country, date)
             if notes:
                 info += notes


### PR DESCRIPTION
This fixes `KeyError: u'notes'` exception because many release dates don't have notes. Now `notes` are accessed the same way as `country` and `date` so the `if notes` statement makes more sense (in addition to checking falsy values).