### PR TITLE
Fix Py2 compat: str decode using 3 arg call in Py3

### DIFF
--- a/bin/imdbpy2sql.py
+++ b/bin/imdbpy2sql.py
@@ -38,6 +38,7 @@ except ImportError:
     from md5 import md5
 from gzip import GzipFile
 
+from imdb import PY2
 from imdb.parser.sql.dbschema import DB_SCHEMA, dropTables, createTables, createIndexes
 from imdb.parser.sql import soundex
 from imdb.utils import analyze_title, analyze_name, date_and_notes, \
@@ -818,12 +819,16 @@ class SourceFile(GzipFile):
 
     def readline_NOcheckEnd(self, size=-1):
         line = GzipFile.readline(self, size)
+        if PY2:
+            return line.decode('latin_2', 'ignore')
         return str(line, 'latin_1', 'ignore')
 
     def readline_checkEnd(self, size=-1):
         line = GzipFile.readline(self, size)
         if self.stop is not None and line[:self.stoplen] == self.stop:
             return ''
+        if PY2:
+            return line.decode('latin_2', 'ignore')
         return str(line, 'latin_1', 'ignore')
 
     def getByHashSections(self):

--- a/bin/imdbpy2sql.py
+++ b/bin/imdbpy2sql.py
@@ -820,7 +820,7 @@ class SourceFile(GzipFile):
     def readline_NOcheckEnd(self, size=-1):
         line = GzipFile.readline(self, size)
         if PY2:
-            return line.decode('latin_2', 'ignore')
+            return line.decode('latin_1', 'ignore')
         return str(line, 'latin_1', 'ignore')
 
     def readline_checkEnd(self, size=-1):
@@ -828,7 +828,7 @@ class SourceFile(GzipFile):
         if self.stop is not None and line[:self.stoplen] == self.stop:
             return ''
         if PY2:
-            return line.decode('latin_2', 'ignore')
+            return line.decode('latin_1', 'ignore')
         return str(line, 'latin_1', 'ignore')
 
     def getByHashSections(self):

--- a/imdb/helpers.py
+++ b/imdb/helpers.py
@@ -32,7 +32,7 @@ from gettext import gettext as _
 
 # The modClearRefs can be used to strip names and titles references from
 # the strings in Movie and Person objects.
-from imdb import IMDb, imdbURL_character_base, imdbURL_movie_base, imdbURL_person_base
+from imdb import IMDb, imdbURL_character_base, imdbURL_movie_base, imdbURL_person_base, PY2
 from imdb.Character import Character
 from imdb.Company import Company
 from imdb.linguistics import COUNTRY_LANG
@@ -217,7 +217,11 @@ def makeModCGILinks(movieTxt, personTxt, characterTxt=None, encoding='utf8'):
                 movieID = item.movieID
                 to_replace = movieTxt % {
                     'movieID': movieID,
-                    'title': str(_cgiPrint(to_replace), encoding, 'xmlcharrefreplace')
+                    'title': (
+                        _cgiPrint(to_replace).decode(encoding, 'xmlcharrefreplace')
+                        if PY2 else
+                        str(_cgiPrint(to_replace), encoding, 'xmlcharrefreplace')
+                    )
                 }
             return to_replace
 
@@ -228,7 +232,11 @@ def makeModCGILinks(movieTxt, personTxt, characterTxt=None, encoding='utf8'):
                 personID = item.personID
                 to_replace = personTxt % {
                     'personID': personID,
-                    'name': str(_cgiPrint(to_replace), encoding, 'xmlcharrefreplace')
+                    'name': (
+                        _cgiPrint(to_replace).decode(encoding, 'xmlcharrefreplace')
+                        if PY2 else
+                        str(_cgiPrint(to_replace), encoding, 'xmlcharrefreplace')
+                    )
                 }
             return to_replace
 
@@ -243,7 +251,11 @@ def makeModCGILinks(movieTxt, personTxt, characterTxt=None, encoding='utf8'):
                     return to_replace
                 to_replace = characterTxt % {
                     'characterID': characterID,
-                    'name': str(_cgiPrint(to_replace), encoding, 'xmlcharrefreplace')
+                    'name': (
+                        _cgiPrint(to_replace).decode(encoding, 'xmlcharrefreplace')
+                        if PY2 else
+                        str(_cgiPrint(to_replace), encoding, 'xmlcharrefreplace')
+                    )
                 }
             return to_replace
         s = s.replace('<', '&lt;').replace('>', '&gt;')

--- a/imdb/parser/http/__init__.py
+++ b/imdb/parser/http/__init__.py
@@ -225,6 +225,8 @@ class IMDbURLopener(FancyURLopener):
                               ' falling back to default utf8.', encode)
         if isinstance(content, str):
             return content
+        if PY2:
+            return content.decode(encode, 'replace')
         return str(content, encode, 'replace')
 
     def http_error_default(self, url, fp, errcode, errmsg, headers):

--- a/imdb/parser/sql/__init__.py
+++ b/imdb/parser/sql/__init__.py
@@ -31,7 +31,7 @@ import logging
 from difflib import SequenceMatcher
 from codecs import lookup
 
-from imdb import IMDbBase
+from imdb import IMDbBase, PY2
 from imdb.utils import normalizeName, normalizeTitle, build_title, \
     build_name, analyze_name, analyze_title, \
                         canonicalTitle, canonicalName, re_titleRef, \
@@ -702,6 +702,8 @@ class IMDbSqlAccessSystem(IMDbBase):
                 try:
                     lookup(e)
                     lat1 = akatitle.encode('latin_1', 'replace')
+                    if PY2:
+                        return lat1.decode(e, 'replace')
                     return str(lat1, e, 'replace')
                 except (LookupError, ValueError, TypeError):
                     continue

--- a/imdb/utils.py
+++ b/imdb/utils.py
@@ -1020,7 +1020,7 @@ def _tagAttr(key, fullpath):
         attrs['keytype'] = strType
         tagName = str(key)
     else:
-        tagName = str((key, 'ascii', 'ignore'))
+        tagName = key.decode('ascii', 'ignore') if PY2 else str((key, 'ascii', 'ignore'))
     if isinstance(key, int):
         attrs['keytype'] = 'int'
     origTagName = tagName


### PR DESCRIPTION
This fixes Python2 compatibility. The Python 3 `class str(object=b'', encoding='utf-8', errors='strict')` signature is not supported so we have to manually call `obj.decode` 

Co-authored-by: @drbig 