### PR TITLE
Change logging level to INFO

### DIFF
--- a/imdb/_logging.py
+++ b/imdb/_logging.py
@@ -46,5 +46,5 @@ def setLevel(level):
     """Set logging level for the main logger."""
     level = level.lower().strip()
     imdbpyLogger.setLevel(LEVELS.get(level, logging.NOTSET))
-    imdbpyLogger.log(imdbpyLogger.level, 'set logging threshold to "%s"',
+    imdbpyLogger.log(logging.INFO, 'set logging threshold to "%s"',
                      logging.getLevelName(imdbpyLogger.level))


### PR DESCRIPTION
Rationale: Changing logging level to `CRITICAL` or `WARNING` shouldn't result in logging an event of such level. If someone is using some external logging service like Rollbar or Sentry this results in registering a critical issue and those should be reserved only for times when something really breaks. In other words it's just a _background noise_.


```
2018-07-17 22:31:58,077 CRITICAL [imdbpy] set logging threshold to "CRITICAL"
2018-07-17 22:31:58,077: [CRITICAL: ForkPoolWorker-4/_logging:50] set logging threshold to "CRITICAL"
```

Change to logging level is _just an information_.