### PR TITLE
Fix missing currentRole information

### DIFF
--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -678,7 +678,7 @@ class DOMHTMLMovieParser(DOMParserBase):
         misc_sections = data.get('misc sections')
         if misc_sections is not None:
             for section in misc_sections:
-                data.update(section)
+                data = {**data, **section}
             del data['misc sections']
         if 'akas' in data or 'other akas' in data:
             akas = data.get('akas') or []

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -678,7 +678,7 @@ class DOMHTMLMovieParser(DOMParserBase):
         misc_sections = data.get('misc sections')
         if misc_sections is not None:
             for section in misc_sections:
-                data.update(section)
+                data = dict(section, **data)
             del data['misc sections']
         if 'akas' in data or 'other akas' in data:
             akas = data.get('akas') or []

--- a/imdb/parser/http/movieParser.py
+++ b/imdb/parser/http/movieParser.py
@@ -678,7 +678,7 @@ class DOMHTMLMovieParser(DOMParserBase):
         misc_sections = data.get('misc sections')
         if misc_sections is not None:
             for section in misc_sections:
-                data = {**data, **section}
+                data.update(section)
             del data['misc sections']
         if 'akas' in data or 'other akas' in data:
             akas = data.get('akas') or []


### PR DESCRIPTION
This PR fixes issue #144 .
For some reason the `data['misc sections']`  contained a 'cast' key that contained  list of Character objects that were missing  the currentRole information.
Now `data` keys will not be overwritten when merging with `data['misc sections'] `.