### PR TITLE
Sort input file list

### DIFF
--- a/imdb/locale/rebuildmo.py
+++ b/imdb/locale/rebuildmo.py
@@ -27,7 +27,7 @@ import msgfmt
 def rebuildmo():
     lang_glob = 'imdbpy-*.po'
     created = []
-    for input_file in glob.glob(lang_glob):
+    for input_file in sorted(glob.glob(lang_glob)):
         lang = input_file[7:-3]
         if not os.path.exists(lang):
             os.mkdir(lang)


### PR DESCRIPTION
Sort input file list
so that mo files are created in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.

This PR was done while working on reproducible builds for openSUSE.