### PR TITLE
add season and episode in analyze_title for TV series episodes #168

### DIFF
--- a/imdb/utils.py
+++ b/imdb/utils.py
@@ -47,7 +47,7 @@ _utils_logger = logging.getLogger('imdbpy.utils')
 # XXX: probably L, C, D and M are far too much! ;-)
 re_year_index = re.compile(r'\(([0-9\?]{4}(/[IVXLCDM]+)?)\)')
 re_m_episode = re.compile(r'\(TV Episode\)\s+-\s+', re.I)
-re_m_series = re.compile(r'Season\s+\d+\s+\|\s+Episode\s+\d+\s+-', re.I)
+re_m_series = re.compile(r'Season\s+(\d+)\s+\|\s+Episode\s+(\d+)\s+-', re.I)
 re_m_imdbIndex = re.compile(r'\(([IVXLCDM]+)\)')
 re_m_kind = re.compile(
     r'\((TV episode|TV Series|TV mini-series|mini|TV|Video|Video Game|VG|Short|TV Movie|TV Short|V)\)',
@@ -389,6 +389,10 @@ def analyze_title(title, canonical=None, canonicalSeries=None, canonicalEpisode=
         # It's an episode of a series.
         kind = 'episode'
         series_title = title[epindex.end():]
+        season_episode_match = re_m_series.match(series_title)
+        if season_episode_match:
+            result['season'] = int(season_episode_match.groups()[0])
+            result['episode'] = int(season_episode_match.groups()[1])
         series_title = re_m_series.sub('', series_title)
         series_info = analyze_title(series_title)
         result['episode of'] = series_info.get('title')

--- a/tests/test_http_search_movie.py
+++ b/tests/test_http_search_movie.py
@@ -81,3 +81,11 @@ def test_search_movie_entries_should_include_akas(ia):
 def test_search_movie_entries_missing_akas_should_be_excluded(ia):
     movies = ia.search_movie('matrix')
     assert 'akas' not in movies[0]
+
+
+def test_search_movie_episodes_should_include_season_and_number(ia):
+    movies = ia.search_movie('swarley')  # How I Met Your Mother S02E07
+    movie_with_season_and_episode = [m for m in movies if m.movieID == '0875360']
+    assert len(movie_with_season_and_episode) == 1
+    assert movie_with_season_and_episode[0]['season'] == 2
+    assert movie_with_season_and_episode[0]['episode'] == 7


### PR DESCRIPTION
Issue #168 
Add the information of season and episode when parsing TV episodes in movie search

```python
>>> from imdb import IMDb
>>> ia = IMDb()
>>> movies = ia.search_movie('Architect of Destruction')
>>> for m in movies:
...     if m['kind'] == 'episode':
...         print(m['episode of'], m['season'], m['episode'])
... 
How I Met Your Mother 6 5
```

Added a test.