### PR TITLE
fix role for python2

### DIFF
--- a/imdb/utils.py
+++ b/imdb/utils.py
@@ -1219,7 +1219,8 @@ class _Container(object):
             pass
         if not self._roleIsPerson:
             if not isinstance(roleID, (list, tuple)):
-                self.currentRole.characterID = roleID
+                if not(PY2 and isinstance(self.currentRole, unicode)):
+                    self.currentRole.characterID = roleID
             else:
                 for index, item in enumerate(roleID):
                     r = self.__role[index]


### PR DESCRIPTION
Fixed the failing python2 tests. I think the tests I created for my last pr `test_http_movie_full_credit.py` exposed a bug in the python2 code for getting full credits. I checked locally on 2.7 with a commit before my headshot PR and the tests fail in the same way.

To fix it I copied the same check for when an actor has multiple roles (line 1227). Though I admit, I didn't look too hard as to why a `currentRole` gets set to a unicode object on python2 and thus cannot have the `characterID` attribute set.  