### PR TITLE
Add selective season parsing for series

### DIFF
--- a/imdb/__init__.py
+++ b/imdb/__init__.py
@@ -758,7 +758,7 @@ class IMDbBase:
                 mop.update_charactersRefs(ret['charactersRefs'])
         mop.set_data(res, override=0)
 
-        def update_series_seasons(self, mop, season_nums, override=0):
+    def update_series_seasons(self, mop, season_nums, override=0):
         """Given a Movie object with only retrieve the season data.
 
         season_nums is the list of the specific seasons to retrieve.


### PR DESCRIPTION
Changes made:

1. Modified get_movie_episodes method to allow for parsing/fetching of a subset of the series seasons.
2. Created the update_series_seasons method. This is the exposed method that handles only episode retrieval requests for specific seasons.

Resolves #245 