### PR TITLE
Use derived loggers

### DIFF
--- a/imdb/__init__.py
+++ b/imdb/__init__.py
@@ -29,13 +29,12 @@ __all__ = ['IMDb', 'IMDbError', 'Movie', 'Person', 'Character', 'Company',
 VERSION = __version__
 
 
-import logging
 import os
 import sys
 from pkgutil import find_loader
 from types import MethodType, FunctionType
 
-import imdb._logging
+from imdb._logging import imdbpyLogger as _imdb_logger
 from imdb._exceptions import IMDbDataAccessError, IMDbError
 from imdb import Character, Company, Movie, Person
 from imdb.utils import build_company_name, build_name, build_title
@@ -48,9 +47,7 @@ else:
     import configparser
 
 
-_imdb_logger = logging.getLogger('imdbpy')
-_aux_logger = logging.getLogger('imdbpy.aux')
-
+_aux_logger = _imdb_logger.getChild('aux')
 
 # URLs of the main pages for movies, persons, characters and queries.
 imdbURL_base = 'https://www.imdb.com/'
@@ -838,7 +835,7 @@ class IMDbBase:
         info = 'episodes'
 
         res = {}
-        
+
         if info in mop.current_info and not override:
             return
         _imdb_logger.debug('retrieving "%s" info set', info)

--- a/imdb/_exceptions.py
+++ b/imdb/_exceptions.py
@@ -20,18 +20,19 @@ This module provides the exception hierarchy used by the imdb package.
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import logging
+from imdb._logging import imdbpyLogger as logger
 
 
 class IMDbError(Exception):
     """Base class for every exception raised by the imdb package."""
-    _logger = logging.getLogger('imdbpy')
 
     def __init__(self, *args, **kwargs):
         """Initialize the exception and pass the message to the log system."""
         # Every raised exception also dispatch a critical log.
-        self._logger.critical('%s exception raised; args: %s; kwds: %s',
-                              self.__class__.__name__, args, kwargs, exc_info=True)
+        logger.critical(
+            '%s exception raised; args: %s; kwds: %s',
+            self.__class__.__name__, args, kwargs, exc_info=True
+        )
         Exception.__init__(self, *args, **kwargs)
 
 

--- a/imdb/parser/http/__init__.py
+++ b/imdb/parser/http/__init__.py
@@ -26,7 +26,6 @@ or "html" (this is the default).
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import logging
 import socket
 import ssl
 from codecs import lookup
@@ -35,6 +34,7 @@ import warnings
 from imdb import PY2
 from imdb import IMDbBase
 from imdb.utils import analyze_title
+from imdb.parser.http.logging import logger
 from imdb._exceptions import IMDbDataAccessError, IMDbParserError
 
 from . import (
@@ -58,7 +58,7 @@ else:
     from urllib.request import HTTPSHandler, ProxyHandler, build_opener
 
 # Logger for miscellaneous functions.
-_aux_logger = logging.getLogger('imdbpy.parser.http.aux')
+_aux_logger = logger.getChild('aux')
 
 
 class _ModuleProxy:
@@ -152,7 +152,7 @@ class IMDbHTTPSHandler(HTTPSHandler, object):
 
 class IMDbURLopener:
     """Fetch web pages and handle errors."""
-    _logger = logging.getLogger('imdbpy.parser.http.urlopener')
+    _logger = logger.getChild('urlopener')
 
     def __init__(self, *args, **kwargs):
         self._last_url = ''
@@ -267,7 +267,7 @@ class IMDbHTTPAccessSystem(IMDbBase):
     """The class used to access IMDb's data through the web."""
 
     accessSystem = 'http'
-    _http_logger = logging.getLogger('imdbpy.parser.http')
+    _http_logger = logger
 
     def __init__(self, adultSearch=True, proxy=-1, cookie_id=-1,
                  timeout=30, cookie_uu=None, *arguments, **keywords):
@@ -607,9 +607,9 @@ class IMDbHTTPAccessSystem(IMDbBase):
                 season_nums = [season_nums]
         if not temp_d and 'data' in temp_d:
             return {}
-            
+
         _seasons = temp_d['data'].get('_seasons') or []
-        
+
         nr_eps = 0
         data_d = dict()
 

--- a/imdb/parser/http/logging.py
+++ b/imdb/parser/http/logging.py
@@ -1,0 +1,3 @@
+from imdb.parser.logging import logger as parent_logger
+
+logger = parent_logger.getChild('http')

--- a/imdb/parser/http/piculet.py
+++ b/imdb/parser/http/piculet.py
@@ -26,7 +26,6 @@ https://piculet.readthedocs.io/
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import json
-import logging
 import os
 import re
 import sys
@@ -71,7 +70,9 @@ if PY2:
 else:
     from contextlib import redirect_stdout
 
-_logger = logging.getLogger('imdbpy.parser.http')
+from imdb.parser.http.logging import logger
+
+_logger = logger.getChild('piculet')
 
 
 ###########################################################

--- a/imdb/parser/http/utils.py
+++ b/imdb/parser/http/utils.py
@@ -22,7 +22,6 @@ in the :mod:`imdb.parser.http` package.
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import logging
 import re
 
 from imdb import PY2
@@ -30,6 +29,7 @@ from imdb.Character import Character
 from imdb.Movie import Movie
 from imdb.Person import Person
 from imdb.utils import _Container, flatten
+from imdb.parser.http.logging import logger
 
 from .piculet import _USE_LXML, ElementTree, Rules, build_tree, html_to_xhtml
 from .piculet import xpath as piculet_xpath
@@ -90,7 +90,7 @@ def _putRefs(d, re_titles, re_names, lastKey=None):
                 _putRefs(d[k], re_titles, re_names, lastKey=lastKey)
 
 
-_b_p_logger = logging.getLogger('imdbpy.parser.http.build_person')
+_b_p_logger = logger.getChild('build_person')
 
 
 def build_person(txt, personID=None, billingPos=None,
@@ -210,7 +210,7 @@ def build_person(txt, personID=None, billingPos=None,
 
 _re_chrIDs = re.compile('[0-9]{7}')
 
-_b_m_logger = logging.getLogger('imdbpy.parser.http.build_movie')
+_b_m_logger = logger.getChild('build_movie')
 
 # To shrink spaces.
 re_spaces = re.compile(r'\s+')
@@ -379,7 +379,7 @@ class DOMParserBase(object):
     preprocessors = []
     rules = []
 
-    _logger = logging.getLogger('imdbpy.parser.http.domparser')
+    _logger = logger.getChild('domparser')
 
     def __init__(self):
         """Initialize the parser."""

--- a/imdb/parser/logging.py
+++ b/imdb/parser/logging.py
@@ -1,0 +1,3 @@
+from imdb._logging import imdbpyLogger
+
+logger = imdbpyLogger.getChild('parser')

--- a/imdb/parser/sql/__init__.py
+++ b/imdb/parser/sql/__init__.py
@@ -27,7 +27,6 @@ when called with the ``accessSystem`` parameter is set to "sql",
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re
-import logging
 from difflib import SequenceMatcher
 from codecs import lookup
 
@@ -40,11 +39,12 @@ from imdb.utils import normalizeName, normalizeTitle, build_title, \
 from imdb.Person import Person
 from imdb.Movie import Movie
 from imdb.Company import Company
+from imdb.parser.sql.logging import logger
 from imdb._exceptions import IMDbDataAccessError, IMDbError
 
 
 # Logger for miscellaneous functions.
-_aux_logger = logging.getLogger('imdbpy.parser.sql.aux')
+_aux_logger = logger.getChild('aux')
 
 # =============================
 # Things that once upon a time were in imdb.parser.common.locsql.

--- a/imdb/parser/sql/alchemyadapter.py
+++ b/imdb/parser/sql/alchemyadapter.py
@@ -30,11 +30,11 @@ try:
 except ImportError:
     from sqlalchemy import exceptions as exc  # 0.4
 
-_alchemy_logger = logging.getLogger('imdbpy.parser.sql.alchemy')
-
-
 from imdb._exceptions import IMDbDataAccessError
+from imdb.parser.sql.logging import logger
 from .dbschema import *
+
+_alchemy_logger = logger.getChild('alchemy')
 
 # Used to convert table and column names.
 re_upper = re.compile(r'([A-Z])')

--- a/imdb/parser/sql/dbschema.py
+++ b/imdb/parser/sql/dbschema.py
@@ -23,10 +23,10 @@ tables and indexes are also provided.
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import logging
+from imdb.parser.sql.logging import logger
 
 
-_dbschema_logger = logging.getLogger('imdbpy.parser.sql.dbschema')
+_dbschema_logger = logger.getChild('dbschema')
 
 
 # Placeholders for column types.

--- a/imdb/parser/sql/logging.py
+++ b/imdb/parser/sql/logging.py
@@ -1,0 +1,3 @@
+from imdb.parser.logging import logger as parent_logger
+
+logger = parent_logger.getChild('sql')

--- a/imdb/utils.py
+++ b/imdb/utils.py
@@ -21,7 +21,6 @@ This module provides basic utilities for the imdb package.
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import logging
 import re
 import string
 import sys
@@ -32,13 +31,14 @@ from time import strftime, strptime
 from imdb import VERSION
 from imdb import linguistics
 from imdb._exceptions import IMDbParserError
+from imdb._logging import imdbpyLogger
 
 
 PY2 = sys.hexversion < 0x3000000
 
 
 # Logger for imdb.utils module.
-_utils_logger = logging.getLogger('imdbpy.utils')
+_utils_logger = imdbpyLogger.getChild('utils')
 
 # The regular expression for the "long" year format of IMDb, like
 # "(1998)" and "(1986/II)", where the optional roman number (that I call


### PR DESCRIPTION
Related to #274 

Instead of getting a named logger using the core logging package in every module, which is susceptible for typos, it now uses derived loggers by calling the `getChild` method on parent logger instances. This way we only provide the logger suffix, not the whole name.

@alberanid Maybe all `aux`-suffixed loggers should be deprecated in favour of package root loggers? For example instead of using `imdbpy.parser.http.aux`, the `imdbpy.parser.http` (that's now defined as `imdb.parser.http.logging.logger`) is enough?