### PR TITLE
msgfmt.py: use array.tobytes() on Python >= 3.2

### DIFF
--- a/imdb/locale/msgfmt.py
+++ b/imdb/locale/msgfmt.py
@@ -87,7 +87,10 @@ def generate():
                          7*4,               # start of key index
                          7*4+len(keys)*8,   # start of value index
                          0, 0)              # size and offset of hash table
-    output += array.array("i", offsets).tostring()
+    if sys.version_info < (3, 2):
+        output += array.array("i", offsets).tostring()
+    else:
+        output += array.array("i", offsets).tobytes()
     output += ids
     output += strs
     return output


### PR DESCRIPTION
array.tostring() was deprecated in Python 3.2 and removed in 3.9.