### PR TITLE
Change get_movie_episodes season_nums to accept any sequence or iterable

### DIFF
--- a/imdb/parser/http/__init__.py
+++ b/imdb/parser/http/__init__.py
@@ -611,9 +611,11 @@ class IMDbHTTPAccessSystem(IMDbBase):
     def get_movie_episodes(self, movieID, season_nums='all'):
         cont = self._retrieve(self.urls['movie_main'] % movieID + 'episodes')
         temp_d = self.mProxy.season_episodes_parser.parse(cont)
-        if not isinstance(season_nums, list):
-            if season_nums != 'all':
-                season_nums = [season_nums]
+        if isinstance(season_nums, int):
+            season_nums = {season_nums}
+        elif (isinstance(season_nums, (list, tuple)) or 
+              not hasattr(season_nums, '__contains__')):
+            season_nums = set(season_nums)
         if not temp_d and 'data' in temp_d:
             return {}
 

--- a/tests/test_http_movie_season_episodes.py
+++ b/tests/test_http_movie_season_episodes.py
@@ -24,3 +24,46 @@ def test_series_episodes_should_contain_rating_and_votes(ia):
     votes = episodes[1][1]['votes']
     assert 8.3 <= rating <= 9.0
     assert votes > 4400
+
+def test_update_series_seasons_single_int(ia):
+    movie = ia.get_movie('0264235')                         # Curb Your Enthusiasm
+    ia.update_series_seasons(movie, season_nums=10)
+    assert 'episodes' in movie
+    assert list(movie['episodes']) == [10]
+
+def test_update_series_seasons_range(ia):
+    movie = ia.get_movie('0264235')                         # Curb Your Enthusiasm
+    ia.update_series_seasons(movie, season_nums=range(3, 10))
+    assert 'episodes' in movie
+    assert list(sorted(movie['episodes'])) == list(range(3, 10))
+
+def test_update_series_seasons_list(ia):
+    movie = ia.get_movie('0264235')                         # Curb Your Enthusiasm
+    ia.update_series_seasons(movie, season_nums=[1, 3, 5])
+    assert 'episodes' in movie
+    assert list(sorted(movie['episodes'])) == [1, 3, 5]
+
+def test_update_series_seasons_tuple(ia):
+    movie = ia.get_movie('0264235')                         # Curb Your Enthusiasm
+    ia.update_series_seasons(movie, season_nums=(1, 3, 5))
+    assert 'episodes' in movie
+    assert list(sorted(movie['episodes'])) == [1, 3, 5]
+
+def test_update_series_seasons_set(ia):
+    movie = ia.get_movie('0264235')                         # Curb Your Enthusiasm
+    ia.update_series_seasons(movie, season_nums={1, 3, 5})
+    assert 'episodes' in movie
+    assert list(sorted(movie['episodes'])) == [1, 3, 5]
+
+def test_update_series_seasons_iterable(ia):
+    movie = ia.get_movie('0264235')                         # Curb Your Enthusiasm
+    ia.update_series_seasons(movie, season_nums=(i for i in range(6) if i % 2))
+    assert 'episodes' in movie
+    assert list(sorted(movie['episodes'])) == [1, 3, 5]
+
+def test_update_series_seasons_less_season_available(ia):
+    movie = ia.get_movie('0185906')                         # Band of Brothers
+    # Only 1 season but request 9
+    ia.update_series_seasons(movie, season_nums=range(1, 10))
+    assert 'episodes' in movie
+    assert list(movie['episodes']) == [1]


### PR DESCRIPTION
Closes #300 
`season_nums` parameter of `IMDbHTTPAccessSystem.get_movie_episodes` and `IMDbHTTPAccessSystem.update_series_seasons` can now accept any sequence or iterable type.
Python `set` type is used internally for lists, tuples or any other object that does not implement `in` operator, otherwise the object's own `in` (`__contains__`) implementation is used. Single `int` parameters (not in a list) are also supported, as before.
I've added some tests. The test runner does not work on my system but running the tests manually works.