### PR TITLE
Update s3.rst

### DIFF
--- a/docs/usage/s3.rst
+++ b/docs/usage/s3.rst
@@ -38,7 +38,7 @@ and you can use the normal IMDbPY API:
 
    from imdb import IMDb
 
-   ia = IMDb('s3', 'postgres://user:password@localhost/imdb')
+   ia = IMDb('s3', 'postgresql://user:password@localhost/imdb')
 
    results = ia.search_movie('the matrix')
    for result in results:


### PR DESCRIPTION
SQLAlchemy now only supports "postgresql:" and no longer support "postgres:".