### PR TITLE
Fix "kind" for mini-series in search-results #331

### DIFF
--- a/imdb/utils.py
+++ b/imdb/utils.py
@@ -50,7 +50,7 @@ re_m_episode = re.compile(r'\(TV Episode\)\s+-\s+', re.I)
 re_m_series = re.compile(r'Season\s+(\d+)\s+\|\s+Episode\s+(\d+)\s+-', re.I)
 re_m_imdbIndex = re.compile(r'\(([IVXLCDM]+)\)')
 re_m_kind = re.compile(
-    r'\((TV episode|TV Series|TV mini-series|mini|TV|Video|Video Game|VG|Short|TV Movie|TV Short|V)\)',
+    r'\((TV episode|TV Series|TV mini[ -]series|mini|TV|Video|Video Game|VG|Short|TV Movie|TV Short|V)\)',
     re.I
 )
 


### PR DESCRIPTION
Search-results for mini-series reported their "kind" as a movie, instead of the correct result. IMDb apparently spells it as "TV Mini Series" now, but that's not what IMDbPY was looking for.