### PR TITLE
Prevent critical error #330

### DIFF
--- a/imdb/parser/http/__init__.py
+++ b/imdb/parser/http/__init__.py
@@ -629,14 +629,22 @@ class IMDbHTTPAccessSystem(IMDbBase):
         for season in _seasons:
             if season_nums != 'all' and season not in season_nums:
                 continue
-            cont = self._retrieve(
-                self.urls['movie_main'] % movieID + 'episodes?season=' + str(season)
-            )
+            # Prevent Critical error if season is not found #330
+            try:
+                cont = self._retrieve(
+                    self.urls['movie_main'] % movieID + 'episodes?season=' + str(season)
+                )
+            except:
+                pass
             other_d = self.mProxy.season_episodes_parser.parse(cont)
             other_d = self._purge_seasons_data(other_d)
             other_d['data'].setdefault('episodes', {})
-            if not (other_d and other_d['data'] and other_d['data']['episodes'][season]):
-                continue
+            # Prevent Critical error if season is not found #330
+            try:
+                if not (other_d and other_d['data'] and other_d['data']['episodes'][season]):
+                    continue
+            except:
+                pass
             nr_eps += len(other_d['data']['episodes'].get(season) or [])
             if data_d:
                 data_d['data']['episodes'][season] = other_d['data']['episodes'][season]


### PR DESCRIPTION
In the current implementation imdbpy will crash with a citical error if a season is not found.

Reason: Imdbpy assumes a season listed does also exist in the episode list. Sometimes that is not the case, especially when a show only lists episodes by year. This data quality issue depends on each specific tv show, (e.g. "tt0388629": One Piece 1999) - but should never lead to a critical error. 

With "tt0388629" for some reason one season is listed on IMDb, but that season will return a 404, thus the two additional try/catches.