### PR TITLE
Better treatment for @ character in resizeImage()

### DIFF
--- a/imdb/helpers.py
+++ b/imdb/helpers.py
@@ -613,7 +613,13 @@ def resizeImage(image, width=None, height=None, crop=None):
     regexString = r'https://m.media-amazon.com/images/\w/\w+'
 
     resultImage = re.findall(regexString, image)[0]
-    resultImage += '@._V1_'
+        if "@@" in image:
+        resultImage += '@'
+
+    if "@" not in image:
+        resultImage += '._V1_'
+    else:
+        resultImage += '@._V1_'
 
     if width:
         resultImage += 'SX%s_' % width

--- a/imdb/helpers.py
+++ b/imdb/helpers.py
@@ -613,7 +613,7 @@ def resizeImage(image, width=None, height=None, crop=None):
     regexString = r'https://m.media-amazon.com/images/\w/\w+'
 
     resultImage = re.findall(regexString, image)[0]
-        if "@@" in image:
+    if "@@" in image:
         resultImage += '@'
 
     if "@" not in image:


### PR DESCRIPTION
Some images were not evaluated correctly, because of double @ symbol, or its absence.

Samples:

Original
resizeImage(Original, 300, 300)
Status on load

MV5BMjExMDQ4MDc4Ml5BMl5BanBnXkFtZTgwMTMwNzE4MDE@._V1_UY100_CR39,0,100,100_AL_.jpg	MV5BMjExMDQ4MDc4Ml5BMl5BanBnXkFtZTgwMTMwNzE4MDE@._V1_SX300_SY300_.jpg
OK

MV5BMTQ4ODU3NDM1Nl5BMl5BanBnXkFtZTgwMTA4NjE4MDE@._V1_UY100_CR39,0,100,100_AL_.jpg
MV5BMTQ4ODU3NDM1Nl5BMl5BanBnXkFtZTgwMTA4NjE4MDE@._V1_SX300_SY300_.jpg
OK

MV5BMjI2NDQ3NDQ1Nl5BMl5BanBnXkFtZTcwOTA3NDc1NA@@._V1_UY100_CR25,0,100,100_AL_.jpg
MV5BMjI2NDQ3NDQ1Nl5BMl5BanBnXkFtZTcwOTA3NDc1NA@._V1_SX300_SY300_.jpg
Not found

MV5BMjAyNzIzNTQ0MV5BMl5BanBnXkFtZTcwMTE3NDc1NA@@._V1_UY100_CR25,0,100,100_AL_.jpg
MV5BMjAyNzIzNTQ0MV5BMl5BanBnXkFtZTcwMTE3NDc1NA@._V1_SX300_SY300_.jpg
Not found

MV5BMjE0ODMwNjAxMF5BMl5BanBnXkFtZTYwODg4MzE3._V1_UY100_CR28,0,100,100_AL_.jpg	MV5BMjE0ODMwNjAxMF5BMl5BanBnXkFtZTYwODg4MzE3@._V1_SX300_SY300_.jpg
Not found

MV5BMTIyMzYzODE2Nl5BMl5BanBnXkFtZTYwMTk5Mzg2._V1_UY100_CR26,0,100,100_AL_.jpg	MV5BMTIyMzYzODE2Nl5BMl5BanBnXkFtZTYwMTk5Mzg2@._V1_SX300_SY300_.jpg
Not found
