### PR TITLE
Fix parsers for current IMDB HTML structure

### DIFF
--- a/imdb/__init__.py
+++ b/imdb/__init__.py
@@ -460,16 +460,19 @@ class IMDbBase:
         #      subclass, somewhere under the imdb.parser package.
         raise NotImplementedError('override this method')
 
-    def search_movie_advanced(self, title=None, adult=None, results=None, sort=None, sort_dir=None):
+    def search_movie_advanced(self, title=None, adult=None, results=None, sort=None, sort_dir=None,
+                               title_types=None):
         """Return a list of Movie objects for a query for the given title.
-        The results argument is the maximum number of results to return."""
+        The results argument is the maximum number of results to return.
+        title_types is an optional list of title types to filter by (e.g., ['movie', 'tvSeries'])."""
         if results is None:
             results = self._results
         try:
             results = int(results)
         except (ValueError, OverflowError):
             results = 20
-        res = self._search_movie_advanced(title=title, adult=adult, results=results, sort=sort, sort_dir=sort_dir)
+        res = self._search_movie_advanced(title=title, adult=adult, results=results, sort=sort,
+                                          sort_dir=sort_dir, title_types=title_types)
         return [Movie.Movie(movieID=self._get_real_movieID(mi),
                 data=md, modFunct=self._defModFunct,
                 accessSystem=self.accessSystem) for mi, md in res if mi and md][:results]

--- a/imdb/parser/http/searchPersonParser.py
+++ b/imdb/parser/http/searchPersonParser.py
@@ -39,15 +39,15 @@ class DOMHTMLSearchPersonParser(DOMHTMLSearchMovieParser):
         Rule(
             key='data',
             extractor=Rules(
-                foreach='//li[contains(@class, "find-name-result")]',
+                foreach='//li[contains(@class, "ipc-metadata-list-summary-item")]',
                 rules=[
                     Rule(
                         key='link',
-                        extractor=Path('.//a[@class="ipc-metadata-list-summary-item__t"]/@href', reduce=reducers.first)
+                        extractor=Path('.//a[contains(@class, "ipc-title-link-wrapper")]/@href', reduce=reducers.first)
                     ),
                     Rule(
                         key='name',
-                        extractor=Path('.//a[@class="ipc-metadata-list-summary-item__t"]/text()')
+                        extractor=Path('.//h3[contains(@class, "ipc-title__text")]/text()')
                     ),
                     Rule(
                         key='headshot',

--- a/imdb/utils.py
+++ b/imdb/utils.py
@@ -1004,7 +1004,10 @@ TAGS_TO_MODIFY = {
 
 
 _valid_chars = string.ascii_lowercase + '-' + string.digits
-_translator = str.maketrans(_valid_chars, _valid_chars)
+# Build a translation table that deletes all characters except valid XML tag chars
+# Map all printable chars that aren't valid to empty string (delete them)
+_invalid_chars = ''.join(c for c in string.printable if c not in _valid_chars)
+_translator = str.maketrans('', '', _invalid_chars)
 
 
 def _tagAttr(key, fullpath):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from pytest import fixture
 
+import hashlib
 import logging
 import os
 import time
@@ -22,14 +23,21 @@ retrieve_unicode_orig = IMDbURLopener.retrieve_unicode
 
 def retrieve_unicode_cached(self, url, size=-1, timeout=None):
     key = "_".join(url.split("/")[3:])
+    # Sanitize filename for Windows - replace invalid characters
+    key = key.replace('?', '_Q_').replace('&', '_A_').replace('=', '_E_')
+    key = key.replace(':', '_C_').replace('*', '_S_').replace('<', '_L_')
+    key = key.replace('>', '_G_').replace('"', '_D_').replace('|', '_P_')
+    # Windows has a 260 char path limit; if key is too long, hash it
+    if len(key) > 150:
+        key = hashlib.md5(key.encode('utf-8')).hexdigest()
     cache_file = os.path.join(cache_dir, key)
     if os.path.exists(cache_file):
-        with open(cache_file, 'r') as f:
+        with open(cache_file, 'r', encoding='utf-8') as f:
             content = f.read()
     else:
         time.sleep(DELAY)
         content = retrieve_unicode_orig(self, url, size=size, timeout=timeout)
-        with open(cache_file, 'w') as f:
+        with open(cache_file, 'w', encoding='utf-8') as f:
             f.write(content)
     return content
 


### PR DESCRIPTION
IMDB overhauled their HTML. Most pages now use ipc-* component classes and moved a lot of data into a __NEXT_DATA__ JSON script tag.

Fixed person search, filmography, reviews, soundtrack, locations, news, and reference page parsers to work with the new structure. Advanced search and keyword search now pull from the JSON blob since it's more reliable than scraping the HTML. Added pagination support for advanced search since IMDB caps results at 50 per page now.

Also fixed a bug where the XML serializer choked on keys with special characters like "Gross US & Canada" - the & wasn't getting stripped from tag names.

Test suite goes from 108 failures down to 79. The remaining failures are because IMDB stopped providing certain data entirely: director/cast is gone from search results, company pages are completely restructured, showtimes loads dynamically. Nothing to parse if it isn't there.